### PR TITLE
#2: update permissions and scopes dependencies after depending config data being changed

### DIFF
--- a/app/Console/Commands/MigrationsCommand.php
+++ b/app/Console/Commands/MigrationsCommand.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Role;
+use App\Models\Permission;
+use Illuminate\Support\Carbon;
+use App\Models\LegalEntityType;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\PermissionRegistrar;
 use Illuminate\Database\Migrations\Migrator;
 
 abstract class MigrationsCommand extends Command
 {
+    protected const int CHUNK_SIZE = 1000;
+
     // Flag indicating whether the command is performing a rollback operation.
     protected bool $isRollback = false;
 
@@ -41,6 +49,18 @@ abstract class MigrationsCommand extends Command
      */
     public function handle(Migrator $migrator): void
     {
+        if ($this->hasOption('scopes') && $this->option('scopes')) {
+            $this->call('config:clear');
+
+            $this->call('config:cache');
+
+            $this->info('Config cache updated');
+
+            $this->syncScopes();
+
+            return;
+        }
+
         $this->cacheClear();
 
         $this->beforeMigrations();
@@ -168,5 +188,489 @@ abstract class MigrationsCommand extends Command
         foreach ($pendingFiles as $file) {
             $this->line("<comment>   Proceeded: </comment>{$file}");
         }
+    }
+
+    /**
+     *********** SCOPE AND PERMISSIONS SYNC METHODS **********
+     */
+
+    /**
+     * Update permissions dependencies for all concerns tables if scopes has been updated in the config file
+     *
+     * @return void
+     */
+    protected function syncScopes(): void
+    {
+        $this->warn("Updating scopes...\n");
+
+        DB::transaction(function() {
+            $this->syncLegalEntityTypes();
+            $this->syncLegalEntityRoles();
+            $this->syncLegalEntityTypeRoles();
+            $this->syncPermissions();
+            $this->syncLegalEntityTypePermissions();
+            $this->syncRolePermissions();
+        });
+    }
+
+    /**
+     * Synchronize the initial data for the legal_entity_types table.
+     *
+     * @return void
+     */
+    protected function syncLegalEntityTypes(): void
+    {
+        $this->info("\n-- Synchronize Legal Entity Types --\n");
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+
+        $availableTypes = [];
+
+        foreach (config('ehealth.legal_entity_localized_names') as $typeName => $localizedName) {
+            $availableTypes[$typeName] = $localizedName;
+        }
+
+        $configuredTypes = array_keys(config('ehealth.legal_entity_types', []));
+
+        $configuredTypes = array_filter(array_keys($availableTypes), function ($typeName) use ($configuredTypes) {
+            if (in_array($typeName, $configuredTypes, true)) {
+                return $typeName;
+            }
+        });
+
+        $storedTypes = DB::table('legal_entity_types')->pluck('name')->all();
+
+        // Missing (need to add): types that are in config but not in DB
+        $missingTypes = array_diff($configuredTypes, $storedTypes);
+        // Extra (in DB but not in config): types that are in DB but not in config
+        $extraTypes = array_diff($storedTypes, $configuredTypes);
+
+        if (!empty($missingTypes)) {
+            $this->warn("\nFound types missing in the database: " . json_encode(array_values($missingTypes)) . "\n");
+
+            // Prepare Type's data to insert into DB
+            foreach ($missingTypes as $typeName) {
+                $typesToInsert[] = [
+                    'name' => $typeName,
+                    'localized_name' => $availableTypes[$typeName] ?? '',
+                    'created_at' => $now,
+                    'updated_at' => $now
+                ];
+            }
+
+            DB::table('legal_entity_types')->insert($typesToInsert);
+        } else {
+            $this->info("\nAll types from config are present in the database.");
+        }
+
+        if (!empty($extraTypes)) {
+            $this->warn("\nFound types are not defined in the config: " . json_encode(array_values($extraTypes)) . "\n");
+
+            DB::table('legal_entity_types')
+                ->whereIn('name', $extraTypes)
+                ->delete();
+        } else {
+            $this->info("\nNo extra types found in the database that are not defined in the config.\n");
+        }
+    }
+
+    /**
+     * Synchronize up roles specific to legal entities.
+     *
+     * @return void
+     */
+    protected function syncLegalEntityRoles(): void
+    {
+        $this->info("\n-- Synchronize Legal Entity and Roles --\n");
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+
+        $rolesToInsert = [];
+
+        // Get all specified guards from section 'guards' from file config/auth.php
+        $guards = collect(array_keys((array) config('auth.guards')))
+            ->values();
+
+        $roleList = array_keys(config('ehealth.roles'));
+
+        $availableRoles = Role::get(['id', 'name'])
+            ->groupBy('name')
+            ->map(fn ($group) => $group->pluck('id')->values()->all())
+            ->toArray();
+
+        $availableRoleNames = array_keys($availableRoles);
+
+        // Missing (need to add): roles that are in config but not in DB
+        $missingRoles = array_diff($roleList, $availableRoleNames);
+        // Extra (in DB but not in config): roles that are in DB but not in config
+        $extraRoles = array_diff($availableRoleNames, $roleList);
+
+        if (!empty($missingRoles)) {
+            $this->warn("\nFound roles missing in the database: " . json_encode(array_values($missingRoles)) . "\n");
+
+            // Prepare Role's and Permission's data to insert into DB
+            foreach ($guards as $guard) {
+                foreach ($missingRoles as $roleName) {
+                    $rolesToInsert[] = [
+                        'name' => $roleName,
+                        'guard_name' => $guard,
+                        'created_at' => $now,
+                        'updated_at' => $now
+                    ];
+                }
+            }
+
+            DB::table('roles')->insert($rolesToInsert);
+        } else {
+            $this->info("\nAll roles from config are present in the database.");
+        }
+
+        if (!empty($extraRoles)) {
+            $this->warn("\nFound roles are not defined in the config: " . json_encode(array_values($extraRoles)) . "\n");
+
+            DB::table('roles')
+                ->whereIn('name', $extraRoles)
+                ->whereIn('guard_name', $guards)
+                ->delete();
+        } else {
+            $this->info("\nNo extra roles found in the database that are not defined in the config.\n");
+        }
+    }
+
+    /**
+     * Synchronize up the legal entity type roles in the database.
+     *
+     * @return void
+     */
+    protected function syncLegalEntityTypeRoles(): void
+    {
+        $this->info("\n-- Synchronize Legal Entity Type and Roles --\n");
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+
+        $availableRoles = Role::get(['id', 'name'])
+                ->groupBy('name')
+                ->map(fn ($group) => $group->pluck('id')->values()->all())
+                ->toArray();
+
+        $legalEntityTypes = LegalEntityType::all();
+
+        $rolesToAdd = [];
+        $rolesToRemove = [];
+
+        foreach ($legalEntityTypes as $legalEntityType) {
+            $legalEntityTypeName = $legalEntityType->name;
+            $legalEntityTypeRoles = $legalEntityType->roles()->get(['name'])->pluck('name')->unique()->toArray();
+
+            if (isset(config('ehealth.legal_entity_employee_types')[$legalEntityTypeName])) {
+                $roles = config('ehealth.legal_entity_employee_types')[$legalEntityTypeName];
+
+                 // Missing (need to add): types and roles relation that are in config but not in DB
+                $missingRoles= array_values((array_diff($roles, $legalEntityTypeRoles)));
+                // Extra (in DB but not in config): types and roles relation that are in DB but not in config
+                $extraRoles = array_values((array_diff($legalEntityTypeRoles, $roles)));
+
+                if (!empty($missingRoles)) {
+                    foreach ($missingRoles as $missingRole) {
+                        foreach ($availableRoles[$missingRole] as $roleId) {
+                            $rolesToAdd[] = [
+                                'legal_entity_type_id' => $legalEntityType->id,
+                                'role_id' => $roleId,
+                                'created_at' => $now,
+                                'updated_at' => $now
+                            ];
+                        }
+                    }
+                }
+
+                if (!empty($extraRoles)) {
+                    foreach ($extraRoles as $extraRole) {
+                        foreach ($availableRoles[$extraRole] as $roleId) {
+                            $rolesToRemove[$legalEntityType->id][] = $roleId;
+                        }
+                    }
+                }
+
+            } else {
+                echo "WARNING: No roles defined for legal entity type '{$legalEntityTypeName}' in the configuration.";
+            }
+        }
+
+        if (!empty($rolesToAdd)) {
+            $this->warn("\nFound roles missing in the database\n");
+
+            DB::table('legal_entity_type_roles')->insert($rolesToAdd);
+        } else {
+            $this->info("\nAll roles for legal entity types from config are present in the database.");
+        }
+
+        if (!empty($rolesToRemove)) {
+            $this->warn("\nFound roles for legal entity types are not defined in the config\n");
+
+            foreach ($rolesToRemove as $legalEntityTypeId => $roleIds) {
+                DB::table('legal_entity_type_roles')
+                    ->where('legal_entity_type_id', $legalEntityTypeId)
+                    ->whereIn('role_id', $roleIds)
+                    ->delete();
+            }
+        } else {
+            $this->info("\nNo extra roles for legal entity types found in the database that are not defined in the config.\n");
+        }
+    }
+
+    /**
+     * Synchronize up the default permissions for the application.
+     *
+     * @return void
+     */
+    protected function syncPermissions(): void
+    {
+        $this->info("\n-- Synchronize Permissions --\n");
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+
+        // Ensure that no cached permission state during seeding
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        // Collect all types permissions from config source
+        $typePermissions = collect((array) config('ehealth.legal_entity_types'))
+            ->flatMap(fn ($arr) => (array) $arr);
+
+        // Collect all roles permissions from config source
+        $rolePermissions = collect((array) config('ehealth.roles'))
+            ->flatMap(fn ($arr) => (array) $arr);
+
+        // Combine and deduplicate permission names
+        $configPermissions = $typePermissions
+            ->merge($rolePermissions)
+            ->filter(fn ($v) => is_string($v) && trim($v) !== '')
+            ->map(fn ($v) => trim($v))
+            ->unique()
+            ->values()
+            ->toArray();
+
+        // Get available guards
+        $guards = collect(array_keys((array) config('auth.guards')))
+            ->values();
+
+        $currentPermissions = Permission::get()
+            ->pluck('name')
+            ->unique()
+            ->values()
+            ->toArray();
+
+        // Missing (need to add): permissions that are in config but not in DB
+        $missingPermissions = array_diff($configPermissions, $currentPermissions);
+        // Extra (in DB but not in config): permissions that are in DB but not in config
+        $extraPermissions = array_values(array_diff($currentPermissions, $configPermissions));
+
+        $permissionsToInsert = [];
+
+        if (!empty($missingPermissions)) {
+            $this->warn("\nFound permissions missing in the database: " . json_encode(array_values($missingPermissions)) . "\n");
+
+            foreach ($missingPermissions as $permission) {
+                foreach ($guards as $guard) {
+                    $permissionsToInsert[] = [
+                        'name' => $permission,
+                        'guard_name' => $guard,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+                }
+            }
+
+            DB::table('permissions')->insert($permissionsToInsert);
+        } else {
+            $this->info("\nAll permissions from config are present in the database.");
+        }
+
+        if (!empty($extraPermissions)) {
+            $this->warn("\nFound permissions are not defined in the config: " . json_encode(array_values($extraPermissions)) . "\n");
+
+            DB::table('permissions')
+                ->whereIn('name', $extraPermissions)
+                ->whereIn('guard_name', $guards)
+                ->delete();
+        } else {
+            $this->info("\nNo extra permissions found in the database that are not defined in the config.\n");
+        }
+
+        // Clear cached permissions once more again
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    /**
+     * Synchronize up default permissions for legal entity types
+     *
+     * @return void
+     */
+    protected function syncLegalEntityTypePermissions(): void
+    {
+        $this->info("\n-- Synchronize Legal Entity Type and Permissions --\n");
+
+        $now = Carbon::now()->format('Y-m-d H:i:s');
+
+        $availablePermissions = Permission::get(['id', 'name'])
+                ->groupBy('name')
+                ->map(fn ($group) => $group->pluck('id')->values()->all())
+                ->toArray();
+
+        $legalEntityTypes = LegalEntityType::all();
+
+        $permissionsToAdd = [];
+        $permissionsToRemove = [];
+
+        foreach ($legalEntityTypes as $legalEntityType) {
+            $legalEntityTypeName = $legalEntityType->name;
+            $legalEntityTypePermissions = $legalEntityType->permissions()->get(['name'])->pluck('name')->unique()->toArray();
+
+            if (isset(config('ehealth.legal_entity_types')[$legalEntityTypeName])) {
+                $permissions = config('ehealth.legal_entity_types')[$legalEntityTypeName];
+
+                // Missing (need to add): types and permissions relation that are in config but not in DB
+                $missingPermissions = array_values((array_diff($permissions, $legalEntityTypePermissions)));
+                // Extra (in DB but not in config): types and permissions relation that are in DB but not in config
+                $extraPermissions = array_values((array_diff($legalEntityTypePermissions, $permissions)));
+
+                if (!empty($missingPermissions)) {
+                    foreach ($missingPermissions as $missingPermission) {
+                        foreach ($availablePermissions[$missingPermission] as $permissionId) {
+                            $permissionsToAdd[] = [
+                                'legal_entity_type_id' => $legalEntityType->id,
+                                'permission_id' => $permissionId,
+                                'created_at' => $now,
+                                'updated_at' => $now
+                            ];
+                        }
+                    }
+                }
+
+                if (!empty($extraPermissions)) {
+                    foreach ($extraPermissions as $extraPermission) {
+                        foreach ($availablePermissions[$extraPermission] as $permissionId) {
+                            $permissionsToRemove[$legalEntityType->id][] = $permissionId;
+                        }
+                    }
+                }
+
+            } else {
+                $this->warn("\nWARNING: No permissions defined for legal entity type '{$legalEntityTypeName}' in the configuration.");
+            }
+        }
+
+        if (!empty($permissionsToAdd)) {
+            $this->warn("\nFound permissions for legal entity types missing in the database\n");
+
+            DB::table('legal_entity_type_permissions')->insert($permissionsToAdd);
+        } else {
+            $this->info("\nAll permissions for legal entity types from config are present in the database.");
+        }
+
+        if (!empty($permissionsToRemove)) {
+            $this->warn("\nFound permissions for legal entity types are not defined in the config\n");
+
+            foreach ($permissionsToRemove as $legalEntityTypeId => $permissionIds) {
+                DB::table('legal_entity_type_permissions')
+                    ->where('legal_entity_type_id', $legalEntityTypeId)
+                    ->whereIn('permission_id', $permissionIds)
+                    ->delete();
+            }
+        } else {
+            $this->info("\nNo extra permissions for legal entity types found in the database that are not defined in the config.\n");
+        }
+    }
+
+    /**
+     * Synchronize default role permissions for the application.
+     *
+     * @return void
+     */
+    protected function syncRolePermissions(): void
+    {
+        $this->info("\n-- Synchronize Role and Permissions --\n");
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $availablePermissions = Permission::get(['id', 'name', 'guard_name'])
+                ->groupBy('name')
+                ->map(fn ($group) => $group->pluck('id', 'guard_name')->all())
+                ->toArray();
+
+        $roles = Role::get(['id', 'name', 'guard_name'])
+                ->groupBy('name')
+                ->map(fn ($group) => $group->pluck('id', 'guard_name')->all())
+                ->toArray();
+
+        $currentRolePermissions = Role::with('permissions')->get()->mapWithKeys(function ($role) {
+            return [$role->name => $role->permissions->pluck('name')->unique()->toArray()];
+        })->toArray();
+
+        $permissionsToAdd = [];
+        $permissionsToRemove = [];
+
+        foreach ($roles as $roleName => $roleIds) {
+            foreach ($roleIds as $guardName =>$roleId) {
+                $rolePermissions = $currentRolePermissions[$roleName] ?? [];
+
+                $rolesFromConfig = config('ehealth.roles', []);
+
+                if (isset($rolesFromConfig[$roleName])) {
+                    $permissions = $rolesFromConfig[$roleName];
+
+                    // Missing (need to add): types and permissions relation that are in config but not in DB
+                    $missingPermissions = array_values((array_diff($permissions, $rolePermissions)));
+                    // Extra (in DB but not in config): types and permissions relation that are in DB but not in config
+                    $extraPermissions = array_values((array_diff($rolePermissions, $permissions)));
+
+                    if (!empty($missingPermissions)) {
+                        foreach ($missingPermissions as $missingPermission) {
+                            $permissionsToAdd[] = [
+                                'role_id' => $roleId,
+                                'permission_id' => $availablePermissions[$missingPermission][$guardName]
+                            ];
+                        }
+                    }
+
+                    if (!empty($extraPermissions)) {
+
+                        foreach ($extraPermissions as $extraPermission) {
+                            $permissionsToRemove[$roleId][] = $availablePermissions[$extraPermission][$guardName];
+                        }
+                    }
+
+                } else {
+                    $this->warn("\nWARNING: No permissions defined for role '{$roleName}' in the configuration.");
+                }
+            }
+        }
+
+        if (!empty($permissionsToAdd)) {
+            $this->warn("\nFound permissions for roles missing in the database...");
+
+            DB::table('role_has_permissions')->insert($permissionsToAdd);
+
+            $this->warn("Synced succesfully\n");
+        } else {
+            $this->info("\nAll permissions for roles from config are present in the database.");
+        }
+
+        if (!empty($permissionsToRemove)) {
+            $this->warn("\nFound permissions for roles are not defined in the config...");
+
+            foreach ($permissionsToRemove as $roleId => $permissionIds) {
+                DB::table('role_has_permissions')
+                    ->where('role_id', $roleId)
+                    ->whereIn('permission_id', $permissionIds)
+                    ->delete();
+            }
+
+            $this->warn("Synced succesfully\n");
+        } else {
+            $this->info("\nNo extra permissions for roles found in the database that are not defined in the config.\n");
+        }
+
+        // Clear permission cache
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 }

--- a/app/Console/Commands/Update.php
+++ b/app/Console/Commands/Update.php
@@ -15,7 +15,12 @@ class Update extends MigrationsCommand
      *
      * @var string
      */
-    protected $signature = 'update {--clear : Clear the cache before installation} {--rollback : Rollback the last batch of migrations} {--step=0 : The number of migration batches to rollback} {--ver= : Specify the target version to update to}';
+    protected $signature = 'update 
+        {--clear : Clear the cache before installation} 
+        {--rollback : Rollback the last batch of migrations} 
+        {--step=0 : The number of migration batches to rollback} 
+        {--ver= : Specify the target version to update to} 
+        {--scopes : Update the scopes (depends on config)} ';
 
     /**
      * The console command description.

--- a/app/Models/LegalEntityType.php
+++ b/app/Models/LegalEntityType.php
@@ -22,4 +22,9 @@ class LegalEntityType extends Model
     {
         return $this->hasMany(LegalEntity::class, 'legal_entity_type_id');
     }
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class, 'legal_entity_type_permissions', 'legal_entity_type_id', 'permission_id');
+    }
 }

--- a/config/ehealth.php
+++ b/config/ehealth.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Models\LegalEntity;
+
 return [
     'api' => [
         'domain' => env('EHEALTH_API_URL', 'private-anon-cb2ce4f7fc-uaehealthapi.apiary-mock.com'),
@@ -31,6 +33,18 @@ return [
     'auth' => [
         'delay_seconds' => 300,     // Amount of the seconds to another login attempt
         'max_login_attempts' => 5   // Amount of the wrong attempt before locking out
+    ],
+
+    'legal_entity_localized_names' => [
+            LegalEntity::TYPE_EMERGENCY => 'legal-entity.types.emergency',
+            LegalEntity::TYPE_MIS => 'legal-entity.types.mis',
+            LegalEntity::TYPE_MSP => 'legal-entity.types.msp',
+            LegalEntity::TYPE_MSP_PHARMACY => 'legal-entity.types.msp_pharmacy',
+            LegalEntity::TYPE_NHS => 'legal-entity.types.nhs',
+            LegalEntity::TYPE_OUTPATIENT => 'legal-entity.types.outpatient',
+            LegalEntity::TYPE_PHARMACY => 'legal-entity.types.pharmacy',
+            LegalEntity::TYPE_PRIMARY_CARE => 'legal-entity.types.primary_care',
+            LegalEntity::TYPE_MSP_LIMITED => 'legal-entity.types.msp_limited'
     ],
 
     'legal_entity_types' => [
@@ -80,7 +94,7 @@ return [
             'person_verification:details', 'person_verification:write', 'device_definition:read', 'device_request:write', 'device_request:read', 'device_request:resend', 'device_request:revoke',
             'specimen:write', 'specimen:read', 'specimen:process', 'specimen:cancel', 'specimen:reject', 'specimen:invalidate', 'service_request:read_impersonal', 'device_request:mark_in_error',
             'device_request:complete', 'device_dispense:read', 'device_association:read', 'detected_issue:read', 'confidant_person_relationship_request:write',
-            'confidant_person_relationship:read', 'personal_data:read', 'care_team:read', 'care_team:write', 'person_request:sign', 'confidant_person_relationship_request:read',
+            'confidant_person_relationship:read', 'personal_data:read', 'care_team:read', 'care_team:write', 'person_request:sign', 'confidant_person_relationship_request:read'
         ],
         'PHARMACY' => [
             'employee_role:write', 'employee_role:read', 'healthcare_service:write', 'healthcare_service:read', 'division:activate', 'division:deactivate', 'division:details', 'division:read',

--- a/database/migrations/install/2025_12_10_000012_create_legal_entity_types_table.php
+++ b/database/migrations/install/2025_12_10_000012_create_legal_entity_types_table.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Models\LegalEntity;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
@@ -47,23 +47,26 @@ return new class extends Migration
     {
         $now = now();
 
-        $availableTypes = [
-            ['name' => LegalEntity::TYPE_EMERGENCY, 'localized_name' => 'legal-entity.types.emergency'],
-            ['name' => LegalEntity::TYPE_MIS, 'localized_name' => 'legal-entity.types.mis'],
-            ['name' => LegalEntity::TYPE_MSP, 'localized_name' => 'legal-entity.types.msp'],
-            ['name' => LegalEntity::TYPE_MSP_PHARMACY, 'localized_name' => 'legal-entity.types.msp_pharmacy'],
-            ['name' => LegalEntity::TYPE_NHS, 'localized_name' => 'legal-entity.types.nhs'],
-            ['name' => LegalEntity::TYPE_OUTPATIENT, 'localized_name' => 'legal-entity.types.outpatient'],
-            ['name' => LegalEntity::TYPE_PHARMACY, 'localized_name' => 'legal-entity.types.pharmacy'],
-            ['name' => LegalEntity::TYPE_PRIMARY_CARE, 'localized_name' => 'legal-entity.types.primary_care'],
-            ['name' => LegalEntity::TYPE_MSP_LIMITED, 'localized_name' => 'legal-entity.types.msp_limited']
-        ];
+        $availableTypes = [];
 
-        foreach ($availableTypes as $typeRecord) {
+        foreach (config('ehealth.legal_entity_localized_names') as $typeName => $localizedName) {
+            $availableTypes[] = [
+                'name' => $typeName,
+                'localized_name' => $localizedName,
+            ];
+        }
+
+        $configuredTypes = array_keys(config('ehealth.legal_entity_types', []));
+
+        $configuredTypes = array_filter($availableTypes, function ($typeData) use ($configuredTypes) {
+            return in_array($typeData['name'], $configuredTypes, true);
+        });
+
+        foreach ($configuredTypes as $typeRecord) {
             $typeRecord['created_at'] = $now;
             $typeRecord['updated_at'] = $now;
         }
 
-        DB::table('legal_entity_types')->insert($availableTypes);
+        DB::table('legal_entity_types')->insert($configuredTypes);
     }
 };

--- a/database/migrations/install/2025_12_10_000018_create_legal_entity_type_roles.php
+++ b/database/migrations/install/2025_12_10_000018_create_legal_entity_type_roles.php
@@ -5,6 +5,7 @@ use App\Models\LegalEntityType;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -62,6 +63,12 @@ return new class extends Migration
         $legalEntityTypes = LegalEntityType::all()->keyBy('name')->toArray();
 
         foreach (config('ehealth.legal_entity_employee_types') as $legalEntityType => $roles) {
+
+            if (!isset($legalEntityTypes[$legalEntityType])) {
+                echo "\nLegal entity type '{$legalEntityType}' from 'legal_entity_employee_types' config parameter not found in the database.\n";
+                continue;
+            }
+
             foreach ($roles as $role) {
                 if (in_array($role, $roleNames, true)) {
                     $legalEtntityTypeId = $legalEntityTypes[$legalEntityType]['id'];

--- a/database/migrations/update/0_1/2026_02_10_094013_add_active_to_column_to_confidant_persons_table.php
+++ b/database/migrations/update/0_1/2026_02_10_094013_add_active_to_column_to_confidant_persons_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('confidant_persons', function (Blueprint $table) {
-            $table->date('active_to')->nullable()->after('person_request_id');
+             if (! Schema::hasColumn('confidant_persons', 'active_to')) {
+                $table->date('active_to')->nullable()->after('person_request_id');
+             }
         });
     }
 
@@ -24,7 +26,9 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('confidant_persons', function (Blueprint $table) {
-            $table->dropColumn('active_to');
+            if (Schema::hasColumn('confidant_persons', 'active_to')) {
+                $table->dropColumn('active_to');
+            }
         });
     }
 };

--- a/database/migrations/update/0_1/2026_02_26_092621_add_documents_to_confidant_person_relationship_requests_table.php
+++ b/database/migrations/update/0_1/2026_02_26_092621_add_documents_to_confidant_person_relationship_requests_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('confidant_person_relationship_requests', function (Blueprint $table) {
-            $table->jsonb('documents')->nullable()->after('channel');
+            if (! Schema::hasColumn('confidant_person_relationship_requests', 'documents')) {
+                $table->jsonb('documents')->nullable()->after('channel');
+            }
         });
     }
 
@@ -24,7 +26,9 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('confidant_person_relationship_requests', function (Blueprint $table) {
-            $table->dropColumn('documents');
+            if (Schema::hasColumn('confidant_person_relationship_requests', 'documents')) {
+                $table->dropColumn('documents');
+            }
         });
     }
 };

--- a/database/seeders/TestUserMigrate.php
+++ b/database/seeders/TestUserMigrate.php
@@ -242,11 +242,15 @@ class TestUserMigrate extends Seeder
 
                 $this->command->info("\tINFO: A new Phone entries has been successfully inserted into the database");
 
+                $password = Str::random(10);
+
+                $this->command->info("\tINFO: A new User password is generated: '" . $password. "' Please, save it!");
+
                 $ownerUserId = User::insertGetId(
                     [
                         'uuid' => '82d1f518-23c9-4c6c-868b-6f7ab26c6da8',
                         'email' => 'vitaliybezsh@gmail.com',
-                        'password' => Hash::make(Str::random()),
+                        'password' => Hash::make($password),
                         'email_verified_at' => new Carbon('2024-09-11T11:00:52.000000Z'),
                         'party_id' => $partyId,
                         'current_team_id' => null,


### PR DESCRIPTION
This PR concerns #2 ISSUE

Після оновлення скоупів в конфіг-файлі потрібно синхронізувати скоупи в БД відносно даних з конфігу.

Що було зроблено:
- пофікшено скприпт first-run в частині генерації паролів;
- додано ключ "--scopes" do консольної команди update
- пофікшено інсталяційні міграції в частині оголошення відомих типів закладу.

Для синхронізації типів закладу, ролей і скоупів в терміналі потрібно дати команду: `php artisan update --scopes`