### PR TITLE
#29: fix bug prevents from sync stopped  job continue by hand (by press button)

### DIFF
--- a/app/Core/EHealthJob.php
+++ b/app/Core/EHealthJob.php
@@ -317,12 +317,13 @@ abstract class EHealthJob implements ShouldQueue
 
         // Execute complex query to find users matching three criteria
         $users = User::with('roles', 'permissions')
-            // FIRST CRITERIA: Exclude current user from search (if it still logined but does not have valid token)
-            ->whereNot('users.id', $user->id ?? 0)
+            // FIRST CRITERIA: Exclude current user's party from search (if it still logined but does not have valid token)
+            ->whereNot('users.party_id', $user->party_id ?? 0)
             // SECOND CRITERIA: User must be employee of this legal entity
-            // This creates a LEFT JOIN with employees table and filters by legal_entity_id
-            // SQL equivalent: LEFT JOIN employees ON users.id = employees.user_id WHERE employees.legal_entity_id = ?
-            ->whereHas('employees', fn ($query) => $query->where('legal_entity_id', $legalEntity->id))
+            // This uses nested whereHas to check User -> Party -> Employee relationship
+            // SQL equivalent: EXISTS (SELECT 1 FROM parties JOIN employees ON employees.party_id = parties.id
+            // WHERE parties.id = users.party_id AND employees.legal_entity_id = ?)
+            ->whereHas('party.employees', fn ($query) => $query->where('legal_entity_id', $legalEntity->id))
             // THIRD CRITERIA: User must have active session
             // This creates an EXISTS subquery to check sessions table
             // Using SELECT 1 for performance - we only need to verify existence, not retrieve data


### PR DESCRIPTION
This PR concerns #29 ISSUE

Що було зроблено:
- пофікшено метод getUserWithActiveSession() в класі app/Core/EHealthJob.php, який унеможливлював продовження перерваної синхронізації без релогауту.