### PR TITLE
Fix(employee): Migrate Employee user_id relationship to Party

### DIFF
--- a/app/Livewire/Employee/EmployeeEdit.php
+++ b/app/Livewire/Employee/EmployeeEdit.php
@@ -72,7 +72,7 @@ class EmployeeEdit extends AbstractEmployeeFormManager
         // We reuse the logic to update it.
 
         $employeeRequestData = Arr::only($preparedData, ['position', 'start_date', 'end_date', 'employee_type', 'division_id', 'email']);
-        $employeeRequestData['user_id'] = $this->employee->user_id;
+        $employeeRequestData['user_id'] = $this->employee->party?->users()->first()?->id;
         $employeeRequestData['party_id'] = $this->employee->party->id;
         $employeeRequestData['employee_id'] = $this->employee->id;
 

--- a/app/Livewire/Employee/EmployeeRequestEdit.php
+++ b/app/Livewire/Employee/EmployeeRequestEdit.php
@@ -64,7 +64,7 @@ class EmployeeRequestEdit extends AbstractEmployeeFormManager
         // If it's a SIGNED request being corrected -> Create NEW Draft (Standard logic)
         if (!is_null($this->employeeRequest->uuid)) {
             $employeeRequestData = Arr::only($preparedData, ['position', 'start_date', 'end_date', 'employee_type', 'division_id', 'email']);
-            $employeeRequestData['user_id'] = $this->employeeRequest->user_id;
+            $employeeRequestData['user_id'] = $this->employeeRequest->party?->users()->first()?->id;
             $employeeRequestData['party_id'] = $this->employeeRequest->party_id;
             $employeeRequestData['employee_id'] = $this->employeeRequest->employee_id;
 

--- a/app/Models/Employee/Employee.php
+++ b/app/Models/Employee/Employee.php
@@ -73,7 +73,7 @@ class Employee extends BaseEmployee
 
     public function scopeEmployeeInstance(Builder $query, int $userId, string $legalEntityUUID, array $roles, bool $isInclude = false): void
     {
-        $query->where('user_id', $userId)
+        $query->whereHas('party.users', fn ($q) => $q->where('users.id', $userId))
             ->where('legal_entity_uuid', $legalEntityUUID)
             ->when(
                 $isInclude,
@@ -86,7 +86,7 @@ class Employee extends BaseEmployee
     {
         $query->whereIn('employee_type', $employeeTypes)
             ->where('status', $status)
-            ->where('user_id', $userId)
+            ->whereHas('party.users', fn ($q) => $q->where('users.id', $userId))
             ->where('legal_entity_id', $legalEntityId)
             ->forParty($partyId);
     }

--- a/app/Policies/EmployeePolicy.php
+++ b/app/Policies/EmployeePolicy.php
@@ -43,7 +43,7 @@ class EmployeePolicy
         }
 
         // 3. Check if there is a connection with the user (user_id)
-        if (is_null($employee->userId)) {
+        if (is_null($employee->party?->users()->first()?->id)) {
             return Response::deny(__('employees.policy.no_user_linked'));
         }
 
@@ -80,7 +80,7 @@ class EmployeePolicy
         }
 
         // 2. State Check
-        if (!$employee->userId || !$employee->partyId || !$employee->uuid) {
+        if (!$employee->party?->users()->first()?->id || !$employee->partyId || !$employee->uuid) {
             return Response::deny(__('employees.policy.sync_missing_data'));
         }
 


### PR DESCRIPTION
Resolves #31. Migrates `user_id` mappings to rely on the Party relation directly, eliminating bugs related to outdated or missing `user_id` on the Employee/EmployeeRequest models.