### PR TITLE
Оновлення логіки редагування співробітників та прав доступу

### DIFF
--- a/app/Livewire/Employee/EmployeeEdit.php
+++ b/app/Livewire/Employee/EmployeeEdit.php
@@ -33,7 +33,19 @@ class EmployeeEdit extends AbstractEmployeeFormManager
         $this->loadDictionaries();
         $this->employee = $employee;
         $this->employeeId = $employee->id;
-        $this->isPersonalDataLocked = true;
+        
+        if (is_null($employee->userId)) {
+            session()?->flash('error', 'Користувач має підтвердити вхід');
+            $this->redirectRoute('employee.index', ['legalEntity' => legalEntity()->id]);
+            return;
+        }
+
+        // Check if the Party of this employee holds the Owner position
+        $isOwnerParty = $employee->party->employees()
+            ->where('employee_type', \App\Enums\User\Role::OWNER->value)
+            ->exists();
+            
+        $this->isPersonalDataLocked = $isOwnerParty;
         $this->isPositionDataLocked = true;
         $this->loadDivisions($legalEntity);
 

--- a/app/Livewire/Employee/EmployeeIndex.php
+++ b/app/Livewire/Employee/EmployeeIndex.php
@@ -269,6 +269,11 @@ class EmployeeIndex extends EmployeeComponent
         $this->resetPage();
     }
 
+    public function tryEdit(int $employeeId): void
+    {
+        $this->dispatch('flashMessage', ['message' => 'Користувач має підтвердити вхід', 'type' => 'error']);
+    }
+
     public function deactivate(): void
     {
         // 1. Get the employee record from the database

--- a/resources/views/livewire/employee/employee-index.blade.php
+++ b/resources/views/livewire/employee/employee-index.blade.php
@@ -347,14 +347,14 @@
                                         // Find the last active employee of this person to check the rights
                                         $latestEmployee = $party->employees->first(); // or through the method by which you get a topical position
 
-                                        $isOwner = $latestEmployee && $latestEmployee->employeeType === Role::OWNER->value;
+                                        // Check if ANY of the employee positions for this party is an OWNER
+                                        $isOwner = $party->employees->contains(fn($emp) => $emp->employeeType === Role::OWNER->value);
                                         $hasUserLinked = $latestEmployee && !empty($latestEmployee->userId);
 
                                         // We check the possibility of editing personal data according to your rules:
-                                        // 1. Not the owner 2. There is a tethered user 3. Not exempt
+                                        // 1. Not the owner 3. Not exempt
                                         $canEditParty = $latestEmployee
                                             && !$isOwner
-                                            && $hasUserLinked
                                             && $latestEmployee->status !== \App\Enums\Status::DISMISSED;
                                     @endphp
                                     @can('create', \App\Models\Employee\EmployeeRequest::class)

--- a/resources/views/livewire/employee/parts/actions-dropdown.blade.php
+++ b/resources/views/livewire/employee/parts/actions-dropdown.blade.php
@@ -19,7 +19,7 @@
 
     $showView = $canView;
 
-    $showEdit = $canWrite && $hasUserLinked && !$isOwner && ($isEmployee ? $status !== 'DISMISSED' : $status === 'NEW');
+    $showEdit = $canWrite && !$isOwner && ($isEmployee ? $status !== 'DISMISSED' : $status === 'NEW');
 
     $showSync = $canWrite && ($isEmployee ? !empty($position->uuid) : in_array($status, ['NEW', 'SIGNED', 'APPROVED']));
     $showDelete = $isRequest && $canWrite && $status === 'NEW';
@@ -61,10 +61,17 @@
 
                 @if($showEdit)
                     <li>
-                        <a href="{{ $isEmployee ? route('employee.edit', ['legalEntity' => legalEntity()->id, 'employee' => $position->id]) : route('employee-request.edit', ['legalEntity' => legalEntity()->id, 'employee_request' => $position->id]) }}"
-                           class="flex items-center gap-2 py-2 px-5 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
-                            @icon('edit', 'w-5 h-5') {{ __('forms.edit') }}
-                        </a>
+                        @if($isEmployee && !$hasUserLinked)
+                            <button type="button" wire:click="tryEdit({{ $position->id }})"
+                               class="flex w-full items-center gap-2 py-2 px-5 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors text-left">
+                                @icon('edit', 'w-5 h-5') {{ __('forms.edit') }}
+                            </button>
+                        @else
+                            <a href="{{ $isEmployee ? route('employee.edit', ['legalEntity' => legalEntity()->id, 'employee' => $position->id]) : route('employee-request.edit', ['legalEntity' => legalEntity()->id, 'employee_request' => $position->id]) }}"
+                               class="flex items-center gap-2 py-2 px-5 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
+                                @icon('edit', 'w-5 h-5') {{ __('forms.edit') }}
+                            </a>
+                        @endif
                     </li>
                 @endif
 


### PR DESCRIPTION
Цей PR оновлює логіку доступу до редагування співробітників:
- Вирішує проблему з блокуванням доступу (помилка 403) для користувачів без прив'язаного емейлу на бекенді.
- Додає відповідне повідомлення в UI "Користувач має підтвердити вхід", замість жорсткої помилки доступу.
- Блокує можливість редагування персональних даних для користувачів з роллю Owner.

Закриває #37
