### PR TITLE
#42: add User & Employee ManyToMany relation

### DIFF
--- a/app/Http/Controllers/Auth/EHealthLoginController.php
+++ b/app/Http/Controllers/Auth/EHealthLoginController.php
@@ -188,7 +188,11 @@ class EHealthLoginController extends Controller
             return null;
         }
 
-        ['id' => $ehealthUserId, 'email' => $ehealthEmail] = $userDetailsValidator->validated();
+        [
+            'id' => $ehealthUserId,
+            'email' => $ehealthEmail,
+            'inserted_at' => $ehealthInsertedAt
+        ] = $userDetailsValidator->validated();
 
         if ($ehealthUserId !== $authUserUUID) {
             Log::error(__('auth.login.error.user_identity', [], 'en'));
@@ -207,6 +211,7 @@ class EHealthLoginController extends Controller
                 'uuid' => $ehealthUserId,
                 'email' => $ehealthEmail,
                 'password' => Hash::make($password),
+                'inserted_at' => $ehealthInsertedAt,
                 'email_verified_at' => now()
             ]);
 
@@ -225,7 +230,7 @@ class EHealthLoginController extends Controller
 
         // User can be created before first ehealth login (e.g. OWNER or any local admin)
         if (!$user->uuid) {
-            $user->update(['uuid' => $ehealthUserId]);
+            $user->update(['uuid' => $ehealthUserId, 'inserted_at' => $ehealthInsertedAt]);
         }
 
         setPermissionsTeamId($legalEntity->id);

--- a/app/Jobs/EmployeeDetailsUpsert.php
+++ b/app/Jobs/EmployeeDetailsUpsert.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use Throwable;
+use Carbon\Carbon;
 use App\Core\EHealthJob;
 use App\Enums\JobStatus;
 use App\Models\LegalEntity;
@@ -18,6 +19,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Queue\SerializesModels;
 use App\Classes\eHealth\EHealthResponse;
+use App\Models\Employee\EmployeeRequest;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Middleware\RateLimited;
@@ -84,21 +86,30 @@ class EmployeeDetailsUpsert extends EHealthJob
 
         $users = $this->employee->party->users;
 
-        if ($users->isEmpty()) {
-            Log::info('Employee sync: no any users associated with this employee record yet.', [
-                'employee_id' => $this->employee->id,
-                'employee_uuid' => $this->employee->uuid,
-            ]);
-
-            return;
-        }
-
         $roleName = $this->employee->employee_type;
         $legalEntityId = $this->employee->legal_entity_id;
 
         setPermissionsTeamId($legalEntityId);
 
+        $employeeCreatedTime = EmployeeRequest::where('legal_entity_id', $legalEntityId)
+            ->where('party_id', $this->employee->party->id)
+            ->where("employee_type", $roleName)
+            ->where('division_id', $validatedData['employee']['division_id'] ?? null)
+            ->where('position', $validatedData['employee']['position'])
+            ->where('start_date', $validatedData['employee']['start_date'] ?? null)
+            ->latest('applied_at')->first()?->applied_at;
+
+        $this->employee->update(['inserted_at' => $employeeCreatedTime->format('Y-m-d H:i:s')]);
+
         foreach ($users as $user) {
+            $userCreatedTime = Carbon::parse($user->inserted_at) ?? null;
+
+            if ($userCreatedTime && $userCreatedTime->lessThan($employeeCreatedTime)) {
+                $this->employee->users()->syncWithoutDetaching([$user->id]);
+            } else {
+                continue;
+            }
+
             if (!$user->hasRole($roleName)) {
                 foreach ($this->getGuardsForRole($roleName) as $guard) {
                     Log::info("Assigning role '{$roleName}' to user ID {$user->id} for guard '{$guard}'.");

--- a/app/Jobs/EmployeeRequestDetailsUpsert.php
+++ b/app/Jobs/EmployeeRequestDetailsUpsert.php
@@ -6,10 +6,12 @@ namespace App\Jobs;
 
 use Throwable;
 use App\Core\Arr;
+use Carbon\Carbon;
 use App\Models\User;
 use App\Core\EHealthJob;
 use App\Enums\JobStatus;
 use App\Models\LegalEntity;
+use App\Models\Relations\Party;
 use App\Repositories\Repository;
 use App\Classes\eHealth\EHealth;
 use Spatie\Permission\Models\Role;
@@ -75,9 +77,16 @@ class EmployeeRequestDetailsUpsert extends EHealthJob
 
         $employeeRequestPartyId = $employeeRequestUser?->partyId;
 
+        $partyId = Repository::party()->createPartyByEmployeeRequest($this->employeeRequest, $validatedData['party'])?->id;
+
         $this->employeeRequest->fill(array_merge(
             $response->map($validatedData, $this->legalEntity, $employeeRequestUser?->id ?? null, $employeeRequestPartyId ?? null),
-            ['sync_status' => JobStatus::COMPLETED->value])
+                [
+                    'sync_status' => JobStatus::COMPLETED->value,
+                    'party_id' => $partyId,
+                    'applied_at' => $validatedData['updated_at'] ?? Carbon::now()
+                ]
+            )
         );
 
         $this->employeeRequest->save();
@@ -108,7 +117,6 @@ class EmployeeRequestDetailsUpsert extends EHealthJob
             ? new CompleteSync($this->legalEntity, isFirstLogin: $this->isFirstLogin)
             : $this->nextEntity;
     }
-
 
     /**
      * Determine which authentication guards define the given role.

--- a/app/Jobs/EmployeeRequestsSyncAll.php
+++ b/app/Jobs/EmployeeRequestsSyncAll.php
@@ -51,13 +51,13 @@ class EmployeeRequestsSyncAll extends EHealthJob
      * Get the next entity job to be scheduled after EmployeeRequestSync completes.
      *
      * If the job is standalone, returns a CompleteSync job for the current legal entity.
-     * Otherwise, returns a chain of EmployeeDetailsUpsert jobs for employees with PARTIAL sync status.
+     * Otherwise, returns a chain of EmployeeRequestDetailsUpsert jobs for employee requests with PARTIAL sync status.
      *
      * @return EHealthJob|null
      */
     protected function getNextEntityJob(): ?EHealthJob
     {
-        $nextEntity = $this->nextEntity ?? $this->getEmployeeRequestDetailsStartJob($this->legalEntity, $this->nextEntity);
+        $nextEntity = $this->getEmployeeRequestDetailsStartJob($this->legalEntity, $this->nextEntity) ?? $this->nextEntity;
 
         return $this->standalone || !$nextEntity
             ? new CompleteSync($this->legalEntity, isFirstLogin: $this->isFirstLogin)

--- a/app/Jobs/PartyVerificationSync.php
+++ b/app/Jobs/PartyVerificationSync.php
@@ -52,4 +52,16 @@ class PartyVerificationSync extends EHealthJob
             'trace' => $exception->getTraceAsString(),
         ]);
     }
+
+    /**
+     * Get next entity job if needed.
+     *
+     * @return EHealthJob|null
+     */
+    protected function getNextEntityJob(): ?EHealthJob
+    {
+        return $this->standalone || !$this->nextEntity
+            ? new CompleteSync($this->legalEntity, isFirstLogin: $this->isFirstLogin)
+            : $this->nextEntity;
+    }
 }

--- a/app/Listeners/FirstLoginOwnerSynchronization.php
+++ b/app/Listeners/FirstLoginOwnerSynchronization.php
@@ -15,6 +15,8 @@ use App\Jobs\LegalEntitySync;
 use App\Jobs\DeclarationsSync;
 use App\Jobs\EmployeeRoleSync;
 use App\Events\EHealthUserLogin;
+use App\Jobs\EmployeeRequestsSyncAll;
+use App\Jobs\PartyVerificationSync;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Bus;
 use App\Notifications\SyncNotification;
@@ -82,6 +84,18 @@ class FirstLoginOwnerSynchronization implements ShouldQueue
         );
 
         $nextJob = new EmployeeSync(
+            legalEntity: $event->legalEntity,
+            nextEntity: $nextJob,
+            isFirstLogin: true
+        );
+
+        $nextJob = new PartyVerificationSync(
+            legalEntity: $event->legalEntity,
+            nextEntity: $nextJob,
+            isFirstLogin: true
+        );
+
+        $nextJob = new EmployeeRequestsSyncAll(
             legalEntity: $event->legalEntity,
             nextEntity: $nextJob,
             isFirstLogin: true

--- a/app/Listeners/PartyVerificationSyncStatusOnLogin.php
+++ b/app/Listeners/PartyVerificationSyncStatusOnLogin.php
@@ -35,6 +35,11 @@ class PartyVerificationSyncStatusOnLogin
      */
     public function handle(EHealthUserLogin $event): void
     {
+        // Skip if this is the first login
+        if ($event->isFirstLogin) {
+            return;
+        }
+
         $user = $event->user;
         $legalEntity = $event->legalEntity;
 

--- a/app/Listeners/eHealth/EmployeeCreate.php
+++ b/app/Listeners/eHealth/EmployeeCreate.php
@@ -8,16 +8,18 @@ use Log;
 use Throwable;
 use App\Core\Arr;
 use Carbon\Carbon;
+use App\Models\User;
 use App\Classes\eHealth\EHealth;
-use App\Enums\Employee\RequestStatus;
-use App\Enums\Employee\RevisionStatus;
 use App\Events\EHealthUserLogin;
-use App\Models\Employee\Employee;
-use App\Models\Employee\EmployeeRequest;
 use App\Repositories\Repository;
+use App\Models\Employee\Employee;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use App\Enums\Employee\RequestStatus;
+use App\Enums\Employee\RevisionStatus;
+use App\Models\Employee\EmployeeRequest;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+
 class EmployeeCreate
 {
     /**
@@ -78,6 +80,7 @@ class EmployeeCreate
                 'legal_entity_id' => $event->legalEntity->uuid,
                 'tax_id' => $taxId,
                 'status' => 'APPROVED',
+                'page_size' => config('ehealth.api.page_size_max') // Get maximum records at one time allowed by EHealth's API (if page_size in .env will set to smaller value, some of employee may be missed)
             ]
         )->validate();
 
@@ -88,9 +91,7 @@ class EmployeeCreate
         // This filters out only uuids associated with the current user
         $existingUuids = Employee::whereIn('uuid', array_column($employees, 'uuid'))
             ->where('legal_entity_id', $event->legalEntity->id)
-            ->where(fn(EloquentBuilder $employeeQuery) =>
-                $employeeQuery->whereHas('party.users')
-            )
+            ->whereHas('users', fn(EloquentBuilder $query) => $query->where('id', $user->id))
             ->pluck('uuid')
             ->all();
 
@@ -100,8 +101,6 @@ class EmployeeCreate
             return;
         }
 
-        $newRoles = [];
-
         DB::transaction(function () use ($user, $employees, $employeeRequests, $event, &$newRoles) {
             foreach ($employees as $eHealthEmployee) {
 
@@ -110,6 +109,9 @@ class EmployeeCreate
                 if (!$employeeRequest) {
                     continue;
                 }
+
+                // If emloyee has already an associated user, we skip attaching because it means it's already created by the stored user (user_id)
+                $eHealthEmployee['user_id'] ??= $user->id;
 
                 $dataFromRevision = EHealth::employeeRequest()->mapCreate($employeeRequest->revision->data);
                 $dataFromEHealth = Arr::only(
@@ -122,12 +124,15 @@ class EmployeeCreate
                     array_merge($dataFromRevision['employee'], $dataFromEHealth, [
                         'legal_entity_id' => $event->legalEntity->id,
                         'legal_entity_uuid' => $event->legalEntity->uuid,
+                        'user_id' => $user->id,
                     ])
                 );
 
                 $cleanPartyFromRevision = $dataFromRevision['party'];
                 $cleanPartyFromEHealth = Arr::except($eHealthEmployee['party'] ?? [], ['email']);
                 $mergedCleanPartyData = array_merge($cleanPartyFromRevision, $cleanPartyFromEHealth);
+
+                $newEmployee->users()->syncWithoutDetaching([$user->id]);
 
                 $newEmployee = Repository::employee()->updateDetails(
                     $newEmployee,
@@ -151,7 +156,6 @@ class EmployeeCreate
                     [
                         'employee_id' => $newEmployee->id,
                         'status' => RequestStatus::APPROVED,
-                        'applied_at' => now(),
                         'user_id' => $user->id,
                         'party_id' => $newEmployee->partyId,
                     ]
@@ -159,25 +163,48 @@ class EmployeeCreate
 
                 $employeeRequest->revision->update(['status' => RevisionStatus::APPLIED]);
 
-                if (!$user->hasRole($newEmployee->employeeType)) {
-                    $newRoles[] = $newEmployee->employeeType;
-                }
+                $users = $newEmployee->party->users;
+
+                $newEmployee->users()->syncWithoutDetaching([$user->id]);
+
+                $employeeInsertedTime = $newEmployee->insertedAt ?? $employeeRequest->appliedAt;
+
+                // Get employees in the same party that have users, were created after the current employee,
+                // and are not already associated with the current user.
+                // This ensures that the current user is linked to all relevant employee records in the party
+                // that were created after the user's creation time, while avoiding associations with future records
+                // that may not be relevant to the user's current session.
+                $employeesIds = $newEmployee->party
+                    ->employees()
+                    ->has('users')
+                    ->where('user_id', '!=', $user->id)
+                    ->where('inserted_at', '>', $employeeInsertedTime)
+                    ->get()
+                    ->pluck('id')
+                    ->toArray();
+
+                // Sync current user to older employees in the party
+                $user->employees()->syncWithoutDetaching($employeesIds);
+
+                // Get users associated with the employee's party that were created before the employee record was inserted,
+                // ensuring proper association of existing users to the new employee record without linking future users
+                // that may not be relevant to the current session.
+                $userIds = $users
+                    ->filter(fn($usr) => Carbon::parse($usr->inserted_at)->lessThan($employeeInsertedTime))
+                    ->pluck('id')
+                    ->all();
+
+                // Sync older users to the new employee
+                $newEmployee->users()->syncWithoutDetaching($userIds);
             }
         });
 
-        if (!empty($newRoles)) {
-            $cleanRoles = array_filter($newRoles, static function ($roleName) {
-                return !(empty($roleName) || !is_string($roleName));
-            });
+        $newRoles = $this->getRolesForParty($user);
 
-            if (empty($cleanRoles)) {
-                return;
-            }
+        setPermissionsTeamId($event->legalEntity->id);
+        $user->unsetRelation('roles')->unsetRelation('permissions');
 
-            setPermissionsTeamId($event->legalEntity->id);
-            $user->unsetRelation('roles')->unsetRelation('permissions');
-            $user->assignRole($cleanRoles);
-        }
+        $user->assignRole($newRoles);
     }
 
     /**
@@ -206,5 +233,29 @@ class EmployeeCreate
 
                 return $namesMatch && $datesMatch;
             });
+    }
+
+    /**
+     * Get roles based on employee types associated with the user's party.
+     *
+     * Only includes employee types where the user was created before or at the same time
+     * as the employee record was inserted, ensuring proper role assignment chronology.
+     *
+     * @param  User  $user
+     *
+     * @return array<string> Array of unique employee type role identifiers.
+     */
+    protected function getRolesForParty(User $user): array
+    {
+        $roles = [];
+        $userCreatedTime = Carbon::parse($user->inserted_at) ?? null;
+
+        foreach ($user->party?->employees as $employee) {
+            if ($employee->employeeType && $employee->insertedAt && $userCreatedTime && $userCreatedTime->lessThanOrEqualTo($employee->insertedAt)) {
+                $roles[] = $employee->employeeType;
+            }
+        }
+
+        return array_unique($roles);
     }
 }

--- a/app/Listeners/eHealth/EmployeeRequestActualize.php
+++ b/app/Listeners/eHealth/EmployeeRequestActualize.php
@@ -19,6 +19,12 @@ class EmployeeRequestActualize
 
     public function handle(EHealthUserLogin $event): void
     {
+        // Skip if this is the first login
+        if ($event->isFirstLogin) {
+            return;
+        }
+
+
         $user = $event->user;
         $legalEntity = $event->legalEntity;
 

--- a/app/Livewire/Employee/EmployeeIndex.php
+++ b/app/Livewire/Employee/EmployeeIndex.php
@@ -14,6 +14,7 @@ use App\Jobs\EmployeeSync;
 use App\Models\Employee\Employee;
 use App\Models\Employee\EmployeeRequest;
 use App\Models\LegalEntity;
+use App\Models\Role as ModelsRole;
 use App\Models\User;
 use App\Notifications\EmployeeSyncCompleted;
 use App\Notifications\SyncNotification;
@@ -23,7 +24,6 @@ use Illuminate\Bus\Batch;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Crypt;
@@ -312,11 +312,21 @@ class EmployeeIndex extends EmployeeComponent
                 // This handles cases where email might be 'N/A' or user doesn't exist locally
                 $users = $employee->party->users;
 
+                // Detach all users from the employee to prevent orphaned relationships
+                $employee->users()->detach();
+
+                // Get all specified guards from section 'guards' from file config/auth.php
+                $guards = array_keys((array) config('auth.guards'));
+
                 foreach ($users as $user) {
                     $roleToRemove = $employee->employee_type;
 
-                    if ($user->hasRole($roleToRemove)) {
-                        $user->removeRole($roleToRemove);
+                    foreach ($guards as $guard) {
+                        if ($user->hasRole($roleToRemove, $guard)) {
+                            $user->removeRole(
+                                ModelsRole::findByName($roleToRemove, $guard)
+                            );
+                        }
                     }
                 }
 

--- a/app/Livewire/LegalEntity/LegalEntity.php
+++ b/app/Livewire/LegalEntity/LegalEntity.php
@@ -786,6 +786,9 @@ abstract class LegalEntity extends Component
 
         // Save the EmployeeRequest emulated response data to the local DB (create the revision record at the same time)
         $employeeRequestHelper->applyUpdateLocalRecords($employeeRequest, $employeeRequestEmulatedData, $legalEntity);
+
+        // This value will be replaced with the real one from the server after the request will be sent
+        $employeeRequest->update(["applied_at" => Carbon::now()->format('Y-m-d')]);
     }
 
     /**

--- a/app/Models/Employee/BaseEmployee.php
+++ b/app/Models/Employee/BaseEmployee.php
@@ -55,6 +55,7 @@ abstract class BaseEmployee extends Model
     protected $casts = [
         'start_date' => EHealthDateCast::class,
         'end_date' => EHealthDateCast::class,
+        'inserted_at' => 'datetime'
     ];
 
     // --- COMMON ACCESSORS ---

--- a/app/Models/Employee/Employee.php
+++ b/app/Models/Employee/Employee.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 namespace App\Models\Employee;
 
-use App\Casts\EHealthDateCast;
-use App\Enums\Party\VerificationStatus;
+use App\Models\User;
 use App\Enums\Status;
 use App\Enums\User\Role;
 use App\Models\Declaration;
+use App\Casts\EHealthDateCast;
 use App\Models\Relations\Education;
+use App\Models\Relations\Speciality;
 use App\Models\Relations\Qualification;
 use App\Models\Relations\ScienceDegree;
-use App\Models\Relations\Speciality;
-use Illuminate\Database\Eloquent\Attributes\Scope;
+use App\Enums\Party\VerificationStatus;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Employee extends BaseEmployee
 {
@@ -33,6 +35,14 @@ class Employee extends BaseEmployee
     ];
 
     // --- EMPLOYEE-SPECIFIC RELATIONS ---
+
+    /**
+     * The users that belong to the employee
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'employee_users', 'employee_id', 'user_id');
+    }
 
     public function declarations(): HasMany
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -56,7 +57,8 @@ class User extends Authenticatable implements MustVerifyEmail
         'email',
         'password',
         'secret_key',
-        'party_id'
+        'party_id',
+        'inserted_at'
     ];
 
     /**
@@ -99,6 +101,14 @@ class User extends Authenticatable implements MustVerifyEmail
     public function person(): BelongsTo
     {
         return $this->belongsTo(Person::class);
+    }
+
+    /**
+     * The employees that belong to the user
+     */
+    public function employees(): BelongsToMany
+    {
+        return $this->belongsToMany(Employee::class, 'employee_users', 'user_id', 'employee_id');
     }
 
     /**

--- a/app/Repositories/EmployeeRepository.php
+++ b/app/Repositories/EmployeeRepository.php
@@ -153,7 +153,17 @@ readonly class EmployeeRepository
     {
         unset($party['email']);
         $partyUuid = Arr::get($party, 'uuid');
-        $partyByUuid = Party::where('uuid', $partyUuid)->first();
+
+        // After EmployeeRequest being synchronized with EHealth, the party can be created in our system without UUID, but with the same personal data.
+        // To avoid duplicates, we need to check if there is a party with the same personal data, and if there is, use it instead of creating a new one.
+        $partyExist =  Party::where('tax_id', $party['tax_id'])
+            ->where('birth_date', $party['birth_date'])
+            ->where('first_name', $party['first_name'])
+            ->where('last_name', $party['last_name'])
+            ->where('second_name', $party['second_name'] ?? null)
+            ?->first();
+
+        $partyByUuid = $partyExist ?? Party::where('uuid', $partyUuid)->first();
 
         // If the model doesn't have a party and party doesn't exist, create new one. It's a brand-new person
         if (!$partyByUuid && !$model->party) {

--- a/app/Repositories/PartyRepository.php
+++ b/app/Repositories/PartyRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Core\Arr;
+use App\Models\Relations\Party;
+use App\Models\Employee\EmployeeRequest;
+
+class PartyRepository
+{
+    /**
+     * Find an existing party or create a new one based on the provided data.
+     *
+     * @param EmployeeRequest $model
+     *
+     * @param array $partyData
+     *
+     * @return Party|null
+     */
+    public function createPartyByEmployeeRequest(EmployeeRequest $model, array $partyData): ?Party
+    {
+        $documents = Arr::pull($partyData, 'documents', []);
+        $phones = Arr::pull($partyData, 'phones', []);
+
+        unset ($partyData['email']);
+
+        $party = Party::where('tax_id', $partyData['tax_id'])
+            ->where('birth_date', $partyData['birth_date'])
+            ->where('first_name', $partyData['first_name'])
+            ->where('last_name', $partyData['last_name'])
+            ->where('second_name', $partyData['second_name'])
+            ->orWhereNull('second_name')
+            ->first();
+
+        if (!empty($party)) {
+            return $party;
+        };
+
+        $newParty = Party::create($partyData);
+
+        $model->party()->associate($newParty)->save();
+
+        $model->party->syncMany('documents', $documents);
+        $model->party->syncMany('phones', $phones);
+
+        return $newParty;
+    }
+}

--- a/app/Repositories/Repository.php
+++ b/app/Repositories/Repository.php
@@ -105,4 +105,9 @@ final class Repository
     {
         return app(RevisionRepository::class);
     }
+
+    public static function party(): PartyRepository
+    {
+        return app(PartyRepository::class);
+    }
 }

--- a/app/Traits/BatchLegalEntityQueries.php
+++ b/app/Traits/BatchLegalEntityQueries.php
@@ -296,7 +296,7 @@ trait BatchLegalEntityQueries
      * @param LegalEntity $legalEntity
      * @param EHealthJob|null $nextEntity The job to be executed after the chain completes (or null)
      *
-     * @return EHealthJob|null The first job in the EmployeeDetailsUpsert chain, or null if there are no employees
+     * @return EHealthJob|null The first job in the EmployeeRequestDetailsUpsert chain, or null if there are no employee_requests
      */
     protected function getEmployeeRequestDetailsStartJob(LegalEntity $legalEntity, ?EHealthJob $nextEntity): ?EHealthJob
     {

--- a/config/ehealth.php
+++ b/config/ehealth.php
@@ -28,6 +28,7 @@ return [
         'cooldown' => 300,
         'retries' => 10,
         'page_size' => env('EHEALTH_PAGE_SIZE', 300),
+        'page_size_max' => env('EHEALTH_PAGE_SIZE_MAX', 500)
     ],
 
     'auth' => [
@@ -161,9 +162,9 @@ return [
         'PRIMARY_CARE' => [
             'OWNER', 'HR', 'DOCTOR', 'ASSISTANT', 'ADMIN', 'RECEPTIONIST', 'MED_ADMIN', 'LABORANT'
         ],
-        'MSP_PHARMACY' => [
-            'OWNER', 'HR', 'DOCTOR', 'ADMIN', 'PHARMACIST', 'RECEPTIONIST'
-        ],
+        // 'MSP_PHARMACY' => [
+        //     'OWNER', 'HR', 'DOCTOR', 'ADMIN', 'PHARMACIST', 'RECEPTIONIST'
+        // ],
         'PHARMACY' => [
             'PHARMACY_OWNER', 'OWNER', 'PHARMACIST', 'HR'
         ],

--- a/database/migrations/install/2025_12_10_000088_create_users_table.php
+++ b/database/migrations/install/2025_12_10_000088_create_users_table.php
@@ -30,6 +30,7 @@ return new class extends Migration
             $table->boolean('is_blocked')->nullable();
             $table->string('block_reason')->nullable();
             $table->foreignId('person_id')->nullable()->constrained('persons')->onDelete('set null');
+            $table->timestamp('inserted_at')->nullable();
 
             $table->timestamps();
         });

--- a/database/migrations/install/2025_12_10_000090_create_employees_table.php
+++ b/database/migrations/install/2025_12_10_000090_create_employees_table.php
@@ -23,12 +23,13 @@ return new class extends Migration
             $table->date('start_date');
             $table->date('end_date')->nullable();
             $table->string('employee_type');
-            $table->date('inserted_at')->nullable();
+            $table->dateTime('inserted_at')->nullable();
             $table->string('status')->nullable();
             $table->enum('sync_status', JobStatus::values())->nullable();
             $table->boolean('is_active')->default(false);
             $table->foreignId('legal_entity_id')->nullable()->constrained('legal_entities')->onDelete('cascade');
             $table->foreignId('division_id')->nullable()->constrained('divisions')->onDelete('cascade');
+            $table->foreignId('user_id')->nullable()->comment("Determine user created for")->constrained('users')->onDelete('cascade');
             $table->foreignId('party_id')->nullable()->constrained('parties')->onDelete('cascade');
             $table->timestamps();
         });

--- a/database/migrations/install/2026_03_04_103846_create_employee_user_table.php
+++ b/database/migrations/install/2026_03_04_103846_create_employee_user_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employee_users', function (Blueprint $table) {
+            $table->foreignId('employee_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+
+            // Set the primary key to be a combination of employee_id and user_id
+            $table->primary(['employee_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_users');
+    }
+};

--- a/database/migrations/update/0_1/2026_02_27_115724_add_uuid_to_confidant_persons_table.php
+++ b/database/migrations/update/0_1/2026_02_27_115724_add_uuid_to_confidant_persons_table.php
@@ -14,7 +14,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('confidant_persons', function (Blueprint $table) {
-            $table->uuid()->after('id');
+            if (! Schema::hasColumn('confidant_persons', 'uuid')) {
+                $table->uuid()->after('id');
+            }
         });
     }
 
@@ -24,7 +26,9 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('confidant_persons', function (Blueprint $table) {
-            $table->dropColumn('uuid');
+            if (Schema::hasColumn('confidant_persons', 'uuid')) {
+                $table->dropColumn('uuid');
+            }
         });
     }
 };

--- a/database/migrations/update/0_1/2026_03_04_103846_create_employee_user_table.php
+++ b/database/migrations/update/0_1/2026_03_04_103846_create_employee_user_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('employee_users')) {
+            Schema::create('employee_users', function (Blueprint $table) {
+                $table->foreignId('employee_id')->constrained()->onDelete('cascade');
+                $table->foreignId('user_id')->constrained()->onDelete('cascade');
+
+                // Set the primary key to be a combination of employee_id and user_id
+                $table->primary(['employee_id', 'user_id']);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('employee_users')) {
+            Schema::dropIfExists('employee_users');
+        }
+    }
+};

--- a/database/migrations/update/0_1/2026_03_04_202834_add_inserted_at_to_users_table.php
+++ b/database/migrations/update/0_1/2026_03_04_202834_add_inserted_at_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'inserted_at')) {
+                $table->timestamp('inserted_at')->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+         Schema::table('users', function (Blueprint $table) {
+            // Check if 'inserted_at' column exists before attempting to drop it
+            if (Schema::hasColumn('users', 'inserted_at')) {
+                $table->dropColumn('inserted_at');
+            }
+        });
+    }
+};

--- a/database/migrations/update/0_1/2026_03_11_160301_change_inserted_at_to_datetime_in_employees_table.php
+++ b/database/migrations/update/0_1/2026_03_11_160301_change_inserted_at_to_datetime_in_employees_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            //Change 'inserted_at' type from date to dateTime
+            $table->dateTime('inserted_at')->nullable()->change();
+        });
+    }
+
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            //Change 'inserted_at' type from dateTime back to date
+            $table->date('inserted_at')->nullable()->change();
+        });
+    }
+};

--- a/database/migrations/update/0_1/2026_03_15_185356_add_user_id_to_employee_table.php
+++ b/database/migrations/update/0_1/2026_03_15_185356_add_user_id_to_employee_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            if (!Schema::hasColumn('employees', 'user_id')) {
+                $table->foreignId('user_id')
+                    ->nullable()
+                    ->comment("Determine user created for")
+                    ->constrained('users')
+                    ->onDelete('cascade');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+         Schema::table('employees', function (Blueprint $table) {
+            // Check if 'user_id' column exists before attempting to drop it
+            if (Schema::hasColumn('employees', 'user_id')) {
+                // Check if foreign key exists
+                $foreignKeys = Schema::getForeignKeys('employees');
+
+                $isForeignKeyPresent = collect($foreignKeys)->contains(function ($fk) {
+                    return in_array('user_id', $fk['columns']);
+                });
+
+                if ($isForeignKeyPresent) {
+                    $table->dropForeign(['user_id']);
+                }
+
+                $table->dropColumn('user_id');
+            }
+        });
+    }
+};

--- a/database/seeders/TestUserMigrate.php
+++ b/database/seeders/TestUserMigrate.php
@@ -260,11 +260,13 @@ class TestUserMigrate extends Seeder
                         'is_blocked' => null,
                         'block_reason' => null,
                         'person_id' => null,
+                        'inserted_at' => new Carbon('2024-06-06T17:07:44Z'),
                         'created_at' => new Carbon('2024-09-11T10:00:52.000000Z'),
                         'updated_at' => new Carbon('2024-09-11T10:03:10.000000Z'),
                         'two_factor_confirmed_at' => null,
                     ]
                 );
+
                 $this->command->info("\tINFO: A new User entry has been successfully inserted into the database");
 
                 $ownerRoleIds = DB::table('roles')->where('name', Role::OWNER)->pluck('id');
@@ -290,9 +292,15 @@ class TestUserMigrate extends Seeder
                     'is_active' => true,
                     'legal_entity_id' => $legalEntityId,
                     'division_id' => null,
+                    'user_id' => $ownerUserId,
                     'party_id' => $partyId,
                     'created_at' => new Carbon('2024-11-14T10:37:35.000000Z'),
                     'updated_at' => new Carbon('2024-11-14T10:37:35.000000Z'),
+                ]);
+
+                DB::table('employee_users')->insert([
+                    'employee_id' => $employeeId,
+                    'user_id' => $ownerUserId,
                 ]);
 
                 $this->command->info("\tINFO: A new Employee entry has been successfully inserted into the database");


### PR DESCRIPTION
This PR concerns #42 ISSUE

Що було зроблено:

- додано відношення employees() до моделі User;
- додано відношення users() до моделі Employee;
- додано відповідну міграцію, яка створює/додає таблицю employee_users;
- підкореговано сідер database/seeders/TestUserMigrate.php: додається відношення між ownerUser і ownerEmployee;
- в таблиці users в колонці inserted_at тепер зберігається час створення користувача на стороні ЕСОЗ як сутності;
- в таблиці employee_requests в колонці applied_at наразі зберігається час прийняття співробітником запрошення на створення посади (фактично - час творення Employee)$
-  в таблиці employee_requests в колонці  party_id тепер коректно визначається party для даного EmployeeRequest. При синхронізації спочатку додається запис в таблицю party, а потім при синхронізації employees для кожного запису в party уточняється його uuid. 
- При першому вході власника закладу коректно призначаються його ролі і встановлюються відношення employee<->user, в залежності від кількості додаткових посад у власника;
- -При першому вході будь-якого іншого співробітника коректно призначаються ті ролі з party, до якої він належить, окрім тих, які не дозволяють йому успішно логінитись. Також коректно визначаються зв1зяки  employee<->user не тільки для цього співробітника, а й для інших, які залежать від нього;
- зроблено коректне видалення ролей і зв'язку Employee<->User при звільненні співробітника;
- при створенні LegalEntity - додається час applied_at до EmployeeRequest запису для коректного відпрацювання першого входу власника.