### PR TITLE
Fix: Associate selected email to new position (#61)

### DIFF
--- a/app/Livewire/Employee/EmployeePositionAdd.php
+++ b/app/Livewire/Employee/EmployeePositionAdd.php
@@ -45,6 +45,11 @@ class EmployeePositionAdd extends AbstractEmployeeFormManager
         }
     }
 
+    public function updatedFormEmail($value): void
+    {
+        $this->form->party['email'] = $value;
+    }
+
     /**
      * Implements the draft persistence logic for adding a new position.
      * It updates the draft if it already exists for this session,


### PR DESCRIPTION
Fixes #61. Added `updatedFormEmail` hook to `EmployeePositionAdd` to ensure the component state is synced when a user selects a different email from the dropdown.