### PR TITLE
#139: fix reorganized LE sync & login

### DIFF
--- a/app/Listeners/eHealth/EmployeeCreate.php
+++ b/app/Listeners/eHealth/EmployeeCreate.php
@@ -82,10 +82,15 @@ class EmployeeCreate
             [
                 'legal_entity_id' => $event->legalEntity->uuid,
                 'tax_id' => $taxId,
-                'status' => Status::APPROVED->value,
                 'page_size' => config('ehealth.api.page_size_max') // Get maximum records at one time allowed by EHealth's API (if page_size in .env will set to smaller value, some of employee may be missed)
             ]
         )->validate();
+
+        // Pass only employees with APPROVED or REORGANIZED status
+        $employees = array_filter(
+            $employees,
+            fn(array $employee) => in_array($employee['status'], [Status::APPROVED->value, Status::REORGANIZED->value])
+        );
 
         if (empty($employees)) {
             return;
@@ -93,7 +98,7 @@ class EmployeeCreate
 
         // This filters out only uuids associated with the current user
         $existingUuids = Employee::whereIn('uuid', array_column($employees, 'uuid'))
-            ->where('status', Status::APPROVED)
+            ->whereIn('status', [Status::APPROVED, Status::REORGANIZED])
             ->where('legal_entity_id', $event->legalEntity->id)
             ->whereNotIn('id', $employeeRequests->pluck('employee_id')->filter()->all())
             ->whereHas('users', fn(EloquentBuilder $query) => $query->where('id', $user->id))
@@ -115,7 +120,7 @@ class EmployeeCreate
                     continue;
                 }
 
-                // If emloyee has already an associated user, skip attaching because it means it's already created by the stored user (user_id)
+                // If employee has already an associated user, skip attaching because it means it's already created by the stored user (user_id)
                 $eHealthEmployee['user_id'] ??= $user->id;
 
                 $dataFromRevision = EHealth::employeeRequest()->mapCreate($employeeRequest->revision->data);
@@ -174,7 +179,7 @@ class EmployeeCreate
             }
         });
 
-        // This means (if NULL) that procceded the first OWNER's login, so we can skip role sync
+        // This means (if NULL) that proceeded the first OWNER's login, so we can skip role sync
         // because roles are assigned based on employee types and employee types are assigned based on employee records that are just created,
         // so if it's first login and OWNER, it means that there is no employee record with employee type OWNER before,
         // so roles will be assigned correctly through EmployeeDetailsUpsert job.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -237,19 +237,21 @@ class User extends Authenticatable implements MustVerifyEmail
             ->where('party_id', $partyId)
             ->where(function (Builder $q) use ($partyId, $legalEntityId) {
                 $employeeBase = Employee::getEmployeesForParty(legalEntityId: $legalEntityId, partyId: $partyId);
+                $employeeBaseReorganized = Employee::getEmployeesForParty(legalEntityId: $legalEntityId, partyId: $partyId, status: Status::REORGANIZED);
 
                 // Users linked via direct employee.user_id column
                 $q->whereIn('id', $employeeBase->whereNotNull('user_id')->select('user_id'))
-                // Users linked via employee_users pivot
-                // NOTE: about reuse of $employeeBase. At the first glance it can be done with mergeConstraintsFrom(),
-                // but trying to reuse the base query directly with methods like mergeConstraintsFrom()
-                // won't work cleanly since that's not a standard Laravel approach.
-                // The simplest solution is to just duplicate the conditions in the orWhereHas callback
-                // rather than trying to extract them into a reusable query builder instance.
+                    ->orWhereIn('id', $employeeBaseReorganized->whereNotNull('user_id')->select('user_id'))
+                    // Users linked via employee_users pivot
+                    // NOTE: about reuse of $employeeBase. At the first glance it can be done with mergeConstraintsFrom(),
+                    // but trying to reuse the base query directly with methods like mergeConstraintsFrom()
+                    // won't work cleanly since that's not a standard Laravel approach.
+                    // The simplest solution is to just duplicate the conditions in the orWhereHas callback
+                    // rather than trying to extract them into a reusable query builder instance.
                     ->orWhereHas('employees', fn (Builder $q1) => $q1
                         ->where('party_id', $partyId)
                         ->where('legal_entity_id', $legalEntityId)
-                        ->where('status', Status::APPROVED)
+                        ->whereIn('status', [Status::APPROVED, Status::REORGANIZED])
                     );
             })
             ->distinct();

--- a/app/Repositories/PartyRepository.php
+++ b/app/Repositories/PartyRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repositories;
 
 use App\Models\User;
+use App\Enums\Status;
 use App\Enums\User\Role;
 use App\Models\LegalEntity;
 use App\Models\Relations\Party;
@@ -19,6 +20,12 @@ class PartyRepository
         $isLegalEntityCanBeReorganized = $legalEntity->type->name  === LegalEntity::TYPE_PRIMARY_CARE || $legalEntity->type->name === LegalEntity::TYPE_OUTPATIENT;
 
         $partyEmployees = Employee::getEmployeesForParty(legalEntityId: $legalEntity->id, partyId: $party->id)->get();
+
+        if ($legalEntity->status === Status::REORGANIZED->value) {
+            $reorganizedEmployees = Employee::getEmployeesForParty(legalEntityId: $legalEntity->id, partyId: $party->id, status: Status::REORGANIZED)->get();
+
+            $partyEmployees = $partyEmployees->merge($reorganizedEmployees)->unique('id')->values();
+        }
 
         // Get all employee-user relations from pivot table for the legal entity to compare with the new candidates we want to sync later
         $pivotEmployeeUsers = $this->getPivotEmployeeUsers($legalEntity->id);


### PR DESCRIPTION
This PR concerns #139 ISSUE

Що було зроблено:
- пофікшено визначення співробітників зі статусом REORGANIZED;
- додана можливість синхронізації реорганізованого закладу, за умови попереднього внесення основних даних (uuid, client_id, clinet_secret, status тощо) по LegalEntity і даних співробітника по OWNER'у в БД (не є типовим процесом реєстрації закладу в МІС). 