### PR TITLE
Resolves #267: Polish and finalize ePrescriptions and electronic referrals integration in Care Plans

### DIFF
--- a/app/Classes/eHealth/Api/Patient/DeviceRequest.php
+++ b/app/Classes/eHealth/Api/Patient/DeviceRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Classes\eHealth\Api\Patient;
+
+use App\Classes\eHealth\EHealthResponse;
+use App\Exceptions\EHealth\EHealthConnectionException;
+use App\Exceptions\EHealth\EHealthResponseException;
+use App\Exceptions\EHealth\EHealthValidationException;
+use GuzzleHttp\Promise\PromiseInterface;
+
+class DeviceRequest extends PatientApiBase
+{
+    /**
+     * Create a Device Request Request (Заявка на направлення виробу).
+     */
+    public function createRequest(string $patientId, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->post(self::URL . "/{$patientId}/device_request_requests", $payload);
+    }
+
+    /**
+     * Sign a Device Request Request (Підпис заявки КЕП).
+     */
+    public function signRequest(string $patientId, string $requestId, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->patch(self::URL . "/{$patientId}/device_request_requests/{$requestId}/actions/sign", $payload);
+    }
+
+    /**
+     * Cancel a Device Request (Скасування направлення на виріб).
+     */
+    public function cancel(string $patientId, string $id, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->patch(self::URL . "/{$patientId}/device_requests/{$id}/actions/cancel", $payload);
+    }
+
+    /**
+     * Get a specific Device Request by ID.
+     */
+    public function getById(string $patientId, string $id, array $query = []): PromiseInterface|EHealthResponse
+    {
+        return $this->get(self::URL . "/{$patientId}/device_requests/{$id}", $query);
+    }
+}

--- a/app/Classes/eHealth/Api/Patient/MedicationRequest.php
+++ b/app/Classes/eHealth/Api/Patient/MedicationRequest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Classes\eHealth\Api\Patient;
+
+use App\Classes\eHealth\EHealthResponse;
+use App\Exceptions\EHealth\EHealthConnectionException;
+use App\Exceptions\EHealth\EHealthResponseException;
+use App\Exceptions\EHealth\EHealthValidationException;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Str;
+
+class MedicationRequest extends PatientApiBase
+{
+    /**
+     * Create a Medication Request Request (Заявка на виписування рецепту).
+     *
+     * @param  string  $patientId
+     * @param  array  $payload
+     * @return PromiseInterface|EHealthResponse
+     * @throws EHealthConnectionException|EHealthValidationException|EHealthResponseException
+     */
+    public function createRequest(string $patientId, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->post(self::URL . "/{$patientId}/medication_request_requests", $payload);
+    }
+
+    /**
+     * Sign a Medication Request Request (Підпис заявки КЕП).
+     *
+     * @param  string  $patientId
+     * @param  string  $requestId
+     * @param  array  $payload
+     * @return PromiseInterface|EHealthResponse
+     * @throws EHealthConnectionException|EHealthValidationException|EHealthResponseException
+     */
+    public function signRequest(string $patientId, string $requestId, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->patch(self::URL . "/{$patientId}/medication_request_requests/{$requestId}/actions/sign", $payload);
+    }
+
+    /**
+     * Cancel a Medication Request (Скасування рецепту).
+     *
+     * @param  string  $patientId
+     * @param  string  $id
+     * @param  array  $payload  Requires 'status_reason' and optional KEP signature info
+     * @return PromiseInterface|EHealthResponse
+     * @throws EHealthConnectionException|EHealthValidationException|EHealthResponseException
+     */
+    public function cancel(string $patientId, string $id, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->patch(self::URL . "/{$patientId}/medication_requests/{$id}/actions/cancel", $payload);
+    }
+
+    /**
+     * Get a specific Medication Request by ID.
+     *
+     * @param  string  $patientId
+     * @param  string  $id
+     * @param  array  $query
+     * @return PromiseInterface|EHealthResponse
+     * @throws EHealthConnectionException|EHealthValidationException|EHealthResponseException
+     */
+    public function getById(string $patientId, string $id, array $query = []): PromiseInterface|EHealthResponse
+    {
+        return $this->get(self::URL . "/{$patientId}/medication_requests/{$id}", $query);
+    }
+
+    /**
+     * Get Medication Requests by search parameters.
+     *
+     * @param  string  $patientId
+     * @param  array  $query
+     * @return PromiseInterface|EHealthResponse
+     * @throws EHealthConnectionException|EHealthValidationException|EHealthResponseException
+     */
+    public function getBySearchParams(string $patientId, array $query = []): PromiseInterface|EHealthResponse
+    {
+        $this->setDefaultPageSize();
+        $mergedQuery = array_merge($this->options['query'], $query);
+
+        return $this->get(self::URL . "/{$patientId}/medication_requests", $mergedQuery);
+    }
+
+    /**
+     * Get Medication Request Requests by search parameters.
+     *
+     * @param  string  $patientId
+     * @param  array  $query
+     * @return PromiseInterface|EHealthResponse
+     * @throws EHealthConnectionException|EHealthValidationException|EHealthResponseException
+     */
+    public function getRequestsBySearchParams(string $patientId, array $query = []): PromiseInterface|EHealthResponse
+    {
+        $this->setDefaultPageSize();
+        $mergedQuery = array_merge($this->options['query'], $query);
+
+        return $this->get(self::URL . "/{$patientId}/medication_request_requests", $mergedQuery);
+    }
+
+    /**
+     * Resend SMS code for Medication Request.
+     *
+     * @param  string  $patientId
+     * @param  string  $id
+     * @return PromiseInterface|\App\Classes\eHealth\EHealthResponse
+     */
+    public function resendOtp(string $patientId, string $id): PromiseInterface|\App\Classes\eHealth\EHealthResponse
+    {
+        return $this->post(self::URL . "/{$patientId}/medication_requests/{$id}/actions/resend_otp", []);
+    }
+}

--- a/app/Classes/eHealth/Api/Patient/ServiceRequest.php
+++ b/app/Classes/eHealth/Api/Patient/ServiceRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Classes\eHealth\Api\Patient;
+
+use App\Classes\eHealth\EHealthResponse;
+use App\Exceptions\EHealth\EHealthConnectionException;
+use App\Exceptions\EHealth\EHealthResponseException;
+use App\Exceptions\EHealth\EHealthValidationException;
+use GuzzleHttp\Promise\PromiseInterface;
+
+class ServiceRequest extends PatientApiBase
+{
+    /**
+     * Create a Service Request Request (Заявка на направлення послуги).
+     */
+    public function createRequest(string $patientId, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->post(self::URL . "/{$patientId}/service_request_requests", $payload);
+    }
+
+    /**
+     * Sign a Service Request Request (Підпис заявки КЕП).
+     */
+    public function signRequest(string $patientId, string $requestId, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->patch(self::URL . "/{$patientId}/service_request_requests/{$requestId}/actions/sign", $payload);
+    }
+
+    /**
+     * Cancel a Service Request (Скасування направлення).
+     */
+    public function cancel(string $patientId, string $id, array $payload): PromiseInterface|EHealthResponse
+    {
+        return $this->patch(self::URL . "/{$patientId}/service_requests/{$id}/actions/cancel", $payload);
+    }
+
+    /**
+     * Get a specific Service Request by ID.
+     */
+    public function getById(string $patientId, string $id, array $query = []): PromiseInterface|EHealthResponse
+    {
+        return $this->get(self::URL . "/{$patientId}/service_requests/{$id}", $query);
+    }
+}

--- a/app/Classes/eHealth/EHealth.php
+++ b/app/Classes/eHealth/EHealth.php
@@ -44,6 +44,9 @@ use App\Classes\eHealth\Api\PersonRequest;
 use App\Classes\eHealth\Api\RuleEngineRules;
 use App\Classes\eHealth\Api\Service;
 use App\Classes\eHealth\Api\Verification;
+use App\Classes\eHealth\Api\Patient\MedicationRequest;
+use App\Classes\eHealth\Api\Patient\ServiceRequest;
+use App\Classes\eHealth\Api\Patient\DeviceRequest;
 
 final class EHealth
 {
@@ -246,5 +249,20 @@ final class EHealth
     public static function diagnosticReport(): DiagnosticReport
     {
         return app(DiagnosticReport::class);
+    }
+
+    public static function medicationRequest(): MedicationRequest
+    {
+        return app(MedicationRequest::class);
+    }
+
+    public static function serviceRequest(): ServiceRequest
+    {
+        return app(ServiceRequest::class);
+    }
+
+    public static function deviceRequest(): DeviceRequest
+    {
+        return app(DeviceRequest::class);
     }
 }

--- a/app/Livewire/CarePlan/CarePlanShow.php
+++ b/app/Livewire/CarePlan/CarePlanShow.php
@@ -816,7 +816,7 @@ class CarePlanShow extends Component
             // Job Polling
             if (isset($responseData['links'][0]['href']) && str_contains($responseData['links'][0]['href'], '/jobs/')) {
                 $jobId = str_replace('/jobs/', '', $responseData['links'][0]['href']);
-                $jobApi = app(\App\Classes\eHealth\Api\Job::class);
+                $jobApi = EHealth::job();
                 $attempts = 0;
                 do {
                     sleep(2);
@@ -1002,7 +1002,7 @@ class CarePlanShow extends Component
             if (isset($responseData['links'][0]['href']) && str_contains($responseData['links'][0]['href'], '/jobs/')) {
                 $jobId = str_replace('/jobs/', '', $responseData['links'][0]['href']);
                 Log::info('CarePlanActivity: Polling job: ' . $jobId);
-                $jobApi = new \App\Classes\eHealth\Api\Job();
+                $jobApi = EHealth::job();
                 $attempts = 0;
                 do {
                     sleep(2);
@@ -1061,8 +1061,9 @@ class CarePlanShow extends Component
             try {
                 $planResponse = EHealth::carePlan()->getDetails($this->carePlan->person->uuid, $this->carePlan->uuid);
                 $repository->syncCarePlans(['data' => [$planResponse->getData()]], $this->carePlan->person_id);
+                $activityRepository->syncActivities($this->carePlan->person, $this->carePlan);
             } catch (\Exception $e) {
-                Log::warning('CarePlanShow: failed to sync plan status after activity: ' . $e->getMessage());
+                Log::warning('CarePlanShow: failed to sync plan status or activities after activity creation: ' . $e->getMessage());
             }
 
             $this->refreshCarePlan();
@@ -1223,7 +1224,7 @@ class CarePlanShow extends Component
                         ]
                     ];
                 }
-                
+
                 if (!empty($this->outcomeReferences)) {
                     $payloadData['outcome_reference'] = collect($this->outcomeReferences)->map(fn($id) => [
                         'identifier' => [
@@ -1845,7 +1846,7 @@ class CarePlanShow extends Component
             
             if (isset($responseData['links'][0]['href']) && str_contains($responseData['links'][0]['href'], '/jobs/')) {
                 $jobId = str_replace('/jobs/', '', $responseData['links'][0]['href']);
-                $jobApi = new \App\Classes\eHealth\Api\Job();
+                $jobApi = EHealth::job();
                 $attempts = 0;
                 do {
                     sleep(2);
@@ -2235,7 +2236,7 @@ class CarePlanShow extends Component
             
             if (isset($responseData['links'][0]['href']) && str_contains($responseData['links'][0]['href'], '/jobs/')) {
                 $jobId = str_replace('/jobs/', '', $responseData['links'][0]['href']);
-                $jobApi = new \App\Classes\eHealth\Api\Job();
+                $jobApi = EHealth::job();
                 $attempts = 0;
                 do {
                     sleep(2);

--- a/app/Livewire/CarePlan/CarePlanShow.php
+++ b/app/Livewire/CarePlan/CarePlanShow.php
@@ -48,6 +48,34 @@ class CarePlanShow extends Component
     public bool $showMedicalDeviceSearchDrawer = false;
     public bool $showMedicalDeviceFormDrawer = false;
 
+    // E-Prescription State Variables
+    public bool $showEPrescriptionDrawer = false;
+    public array $ePrescriptionForm = [];
+    public ?array $ePrescriptionSelectedActivity = null;
+    public ?array $ePrescriptionSelectedProduct = null;
+    public ?array $ePrescriptionSelectedProgram = null;
+    public float $ePrescriptionRemainingQty = 0.0;
+    public bool $ePrescriptionSkipTreatmentPeriod = true;
+    public bool $ePrescriptionShowDailyDoseWarning = false;
+    public bool $ePrescriptionShowRemainingQtyWarning = false;
+    public string $ePrescriptionWarningMessage = '';
+    public array $ePrescriptionMultiples = [];
+    public array $ePrescriptionPackages = [];
+    public array $ePrescriptionAuthMethods = [];
+    public ?string $ePrescriptionRequestIdToSign = null;
+    public string $printableContent = '';
+    public array $activePrescriptions = [];
+
+    // Outgoing Referral State Variables
+    public bool $showReferralDrawer = false;
+    public array $referralForm = [];
+    public ?array $referralSelectedActivity = null;
+    public float $referralRemainingQty = 0.0;
+    public bool $referralShowRemainingQtyWarning = false;
+    public string $referralWarningMessage = '';
+    public ?string $referralRequestIdToSign = null;
+    public array $activeReferrals = [];
+
     // Search and selection parameters
     public string $searchQuery = '';
     public array $searchResults = [];
@@ -156,6 +184,11 @@ class CarePlanShow extends Component
 
         $this->carePlanUuid = $this->carePlan->uuid;
         $this->patientId = $this->carePlan->person->uuid;
+        $this->activePrescriptions = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::whereIn('based_on_id', $this->carePlan->activities->pluck('id'))->get()->toArray();
+        $this->activeReferrals = array_merge(
+            \App\Models\MedicalEvents\Sql\ServiceRequestRequest::whereIn('based_on_id', $this->carePlan->activities->pluck('id'))->get()->toArray(),
+            \App\Models\MedicalEvents\Sql\DeviceRequestRequest::whereIn('based_on_id', $this->carePlan->activities->pluck('id'))->get()->toArray()
+        );
 
         $action = request()->query('action');
         if (in_array($action, ['cancel', 'complete'])) {
@@ -197,10 +230,17 @@ class CarePlanShow extends Component
         return $this->dictionaries['care_plan_cancel_reasons'] ?? [];
     }
 
-    public function openSignatureModal(string $actionType, ?int $activityId = null): void
+    public function openSignatureModal(string $actionType, ?int $activityId = null, ?string $requestUuid = null): void
     {
         $this->actionType = $actionType;
         $this->activityToSign = $activityId;
+        if ($requestUuid) {
+            if ($actionType === 'cancel_prescription') {
+                $this->ePrescriptionRequestIdToSign = $requestUuid;
+            } elseif ($actionType === 'cancel_referral') {
+                $this->referralRequestIdToSign = $requestUuid;
+            }
+        }
         $this->statusReason = ''; // Reset reason
         $this->outcomeCode = ''; // Reset outcome
         $this->outcomeReferences = []; // Reset references
@@ -582,8 +622,28 @@ class CarePlanShow extends Component
             return;
         }
 
+        if ($this->actionType === 'sign_eprescription') {
+            $this->signEPrescription();
+            return;
+        }
+
+        if ($this->actionType === 'sign_servicerequest' || $this->actionType === 'sign_devicerequest') {
+            $this->signReferral();
+            return;
+        }
+
         if (in_array($this->actionType, ['complete_activity', 'cancel_activity'])) {
             $this->signStatusActivity($activityRepository);
+            return;
+        }
+
+        if ($this->actionType === 'cancel_prescription') {
+            $this->signCancelPrescription();
+            return;
+        }
+
+        if ($this->actionType === 'cancel_referral') {
+            $this->signCancelReferral();
             return;
         }
 
@@ -1408,6 +1468,932 @@ class CarePlanShow extends Component
     {
         $this->carePlan->refresh();
         $this->carePlan->load(['person', 'author.party', 'categoryConcept', 'activities.kindConcept.coding']);
+        $this->activePrescriptions = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::whereIn('based_on_id', $this->carePlan->activities->pluck('id'))->get()->toArray();
+        $this->activeReferrals = array_merge(
+            \App\Models\MedicalEvents\Sql\ServiceRequestRequest::whereIn('based_on_id', $this->carePlan->activities->pluck('id'))->get()->toArray(),
+            \App\Models\MedicalEvents\Sql\DeviceRequestRequest::whereIn('based_on_id', $this->carePlan->activities->pluck('id'))->get()->toArray()
+        );
+    }
+
+    public function initEPrescriptionForm(int $activityId, CarePlanActivityRepository $activityRepository): void
+    {
+        $activity = $activityRepository->findById($activityId);
+        if (!$activity) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Призначення не знайдено']);
+            return;
+        }
+
+        $planStatus = strtolower(is_array($this->carePlan->status) 
+            ? ($this->carePlan->status['coding'][0]['code'] ?? ($this->carePlan->status['text'] ?? '')) 
+            : (string) $this->carePlan->status);
+        
+        $activityStatus = strtolower(is_array($activity->status) 
+            ? ($activity->status['coding'][0]['code'] ?? ($activity->status['text'] ?? '')) 
+            : (string) $activity->status);
+
+        $blockedPlanStatuses = ['cancelled', 'completed', 'terminated', 'entered-in-error'];
+        $blockedActivityStatuses = ['cancelled', 'completed'];
+
+        if (in_array($planStatus, $blockedPlanStatuses)) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Виписування рецепту заборонено: план лікування завершено, скасовано або відмінено.']);
+            return;
+        }
+
+        if (in_array($activityStatus, $blockedActivityStatuses)) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Виписування рецепту заборонено: це призначення вже завершено або скасовано.']);
+            return;
+        }
+
+        $this->ePrescriptionSelectedProduct = null;
+        $this->ePrescriptionWarningMessage = '';
+        $this->ePrescriptionPackages = [];
+        $this->ePrescriptionMultiples = [];
+
+        try {
+            $response = EHealth::drug()->getMany(['innm_id' => $activity->product_reference]);
+            $data = $response->getData();
+            if (!empty($data)) {
+                $this->ePrescriptionSelectedProduct = $data[0];
+                if (!empty($this->ePrescriptionSelectedProduct['packages'])) {
+                    $this->ePrescriptionPackages = $this->ePrescriptionSelectedProduct['packages'];
+                    $minQty = $this->ePrescriptionPackages[0]['package_min_qty'] ?? 1;
+                    $multiples = [];
+                    for ($i = 1; $i <= 10; $i++) {
+                        $multiples[] = $minQty * $i;
+                    }
+                    $this->ePrescriptionMultiples = $multiples;
+                }
+            }
+        } catch (\Exception $e) {
+            Log::warning('CarePlanShow: failed to fetch drug details: ' . $e->getMessage());
+        }
+
+        if (!$this->ePrescriptionSelectedProduct) {
+            $this->ePrescriptionSelectedProduct = [
+                'name' => $activity->product_reference,
+                'innm_dosage_form' => 'од.',
+            ];
+        }
+
+        $this->ePrescriptionSelectedProgram = null;
+        $this->ePrescriptionSkipTreatmentPeriod = true;
+        if (!empty($activity->program)) {
+            try {
+                $response = EHealth::medicalProgram()->getMany(['id' => $activity->program]);
+                $data = $response->getData();
+                if (!empty($data)) {
+                    $this->ePrescriptionSelectedProgram = $data[0];
+                    $settings = $this->ePrescriptionSelectedProgram['settings'] ?? [];
+                    $this->ePrescriptionSkipTreatmentPeriod = filter_var($settings['skip_treatment_period'] ?? true, FILTER_VALIDATE_BOOLEAN);
+                }
+            } catch (\Exception $e) {
+                Log::warning('CarePlanShow: failed to fetch medical program: ' . $e->getMessage());
+            }
+        }
+
+        $this->ePrescriptionAuthMethods = [];
+        try {
+            $this->ePrescriptionAuthMethods = EHealth::person()->getAuthMethods($this->carePlan->person->uuid)->getData();
+        } catch (\Exception $e) {
+            Log::warning('CarePlanShow: failed to fetch auth methods: ' . $e->getMessage());
+            $this->ePrescriptionAuthMethods = [
+                ['uuid' => 'offline-method-uuid', 'type' => 'OFFLINE', 'alias' => 'Документи']
+            ];
+        }
+
+        $issuedQty = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::where('based_on_id', $activity->id)
+            ->whereNotIn('status', ['cancelled', 'rejected', 'declined', 'entered-in-error'])
+            ->sum('medication_qty');
+        
+        $activityQty = (float) $activity->quantity;
+        $this->ePrescriptionRemainingQty = max(0.0, $activityQty - $issuedQty);
+
+        $unit = $this->ePrescriptionSelectedProduct['innm_dosage_form'] ?? 'од.';
+
+        $this->ePrescriptionForm = [
+            'activity_id' => $activity->id,
+            'medication_id' => $activity->product_reference,
+            'started_at' => now()->format('d.m.Y'),
+            'duration' => 10,
+            'ended_at' => '',
+            'medication_qty' => !empty($this->ePrescriptionMultiples) ? $this->ePrescriptionMultiples[0] : min($this->ePrescriptionRemainingQty, 10.0),
+            'medication_unit' => $unit,
+            'signature_text' => '',
+            'max_dose_per_period' => (float) $activity->daily_amount ?: 1.0,
+            'max_dose_per_administration' => 1.0,
+            'inform_with' => !empty($this->ePrescriptionAuthMethods) ? ($this->ePrescriptionAuthMethods[0]['uuid'] ?? '') : '',
+            'container_dosage' => '',
+            'program_id' => $activity->program,
+        ];
+
+        $this->ePrescriptionShowDailyDoseWarning = false;
+        $this->ePrescriptionShowRemainingQtyWarning = false;
+        $this->ePrescriptionSelectedActivity = $activity->toArray();
+
+        $this->calculateTreatmentDates();
+        $this->showEPrescriptionDrawer = true;
+    }
+
+    public function updatedEPrescriptionForm($value, $name): void
+    {
+        if (str_contains($name, 'started_at') || str_contains($name, 'duration')) {
+            $this->calculateTreatmentDates();
+        }
+    }
+
+    public function calculateTreatmentDates(): void
+    {
+        if (empty($this->ePrescriptionForm['started_at']) || empty($this->ePrescriptionForm['duration'])) {
+            return;
+        }
+
+        try {
+            $start = \Carbon\Carbon::createFromFormat('d.m.Y', $this->ePrescriptionForm['started_at']);
+            $duration = (int) $this->ePrescriptionForm['duration'];
+            
+            if ($duration < 1) {
+                return;
+            }
+
+            $maxPeriod = (int) ($this->ePrescriptionSelectedProgram['settings']['request_max_period_day'] ?? 90);
+            if ($duration > $maxPeriod) {
+                $this->ePrescriptionWarningMessage = "Тривалість курсу лікування ({$duration} днів) перевищує максимальний період курсу за обраною програмою ({$maxPeriod} днів).";
+            } else {
+                $this->ePrescriptionWarningMessage = '';
+            }
+
+            $end = $start->copy()->addDays($duration - 1);
+            $this->ePrescriptionForm['ended_at'] = $end->format('d.m.Y');
+        } catch (\Exception $e) {
+            // Invalid date format
+        }
+    }
+
+    public function confirmExceededDailyDose(bool $confirm): void
+    {
+        $this->ePrescriptionShowDailyDoseWarning = false;
+        if ($confirm) {
+            if (!str_starts_with($this->ePrescriptionForm['signature_text'], '(!)')) {
+                $this->ePrescriptionForm['signature_text'] = '(!) ' . $this->ePrescriptionForm['signature_text'];
+            }
+            $this->submitEPrescriptionRequest();
+        }
+    }
+
+    public function validateEPrescription(): void
+    {
+        if (empty($this->ePrescriptionForm['inform_with'])) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Необхідно обрати метод автентифікації пацієнта']);
+            return;
+        }
+
+        $qty = (float) $this->ePrescriptionForm['medication_qty'];
+        $maxDosage = (float) ($this->ePrescriptionSelectedProduct['packages'][0]['max_request_dosage'] ?? ($this->ePrescriptionSelectedProduct['max_request_dosage'] ?? 0));
+        
+        if ($maxDosage > 0 && $qty > $maxDosage) {
+            $unit = $this->ePrescriptionForm['medication_unit'] ?? '';
+            $this->ePrescriptionWarningMessage = "Увага! За даним рецептом перевищено максимально допустиму кількість лікарського засобу [{$this->ePrescriptionSelectedProduct['name']}], що дозволена до виписування в 1 рецепті. Максимально допустима кількість ЛЗ становить {$maxDosage} {$unit}. Будь-ласка, поверніться та скоригуйте електронний рецепт!";
+            return;
+        }
+
+        if ($qty > $this->ePrescriptionRemainingQty) {
+            $this->ePrescriptionWarningMessage = "Кількість ЛЗ в рецепті ({$qty}) перевищує залишкову кількість у плані лікування ({$this->ePrescriptionRemainingQty}). Виписування неможливе.";
+            return;
+        }
+
+        if (!$this->ePrescriptionSkipTreatmentPeriod) {
+            $lastActivePrescription = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::where('person_id', $this->carePlan->person_id)
+                ->where('medication_id', $this->ePrescriptionForm['medication_id'])
+                ->whereIn('status', ['active', 'signed'])
+                ->orderBy('ended_at', 'desc')
+                ->first();
+            
+            if ($lastActivePrescription && $lastActivePrescription->ended_at) {
+                $lastEnd = \Carbon\Carbon::parse($lastActivePrescription->ended_at);
+                $today = now();
+                $remainingDays = $today->diffInDays($lastEnd, false);
+                
+                if ($remainingDays > 0) {
+                    $prevDuration = $lastActivePrescription->started_at ? \Carbon\Carbon::parse($lastActivePrescription->started_at)->diffInDays($lastEnd) + 1 : 10;
+                    $allowedDaysBeforeEnd = $prevDuration >= 21 ? 7 : 3;
+                    
+                    if ($remainingDays > $allowedDaysBeforeEnd) {
+                        $this->ePrescriptionWarningMessage = "Повторний Е-Рецепт на той же МНН можна виписати за {$allowedDaysBeforeEnd} днів до закінчення терміну лікування попереднього Е-Рецепту. Попередній рецепт діє до " . $lastEnd->format('d.m.Y') . " (залишилось {$remainingDays} днів).";
+                        return;
+                    }
+                }
+            }
+        }
+
+        $dailyDose = (float) $this->ePrescriptionForm['max_dose_per_period'];
+        $recommendedDailyDose = (float) ($this->ePrescriptionSelectedProduct['daily_dosage'] ?? 0);
+        $planDailyAmount = (float) ($this->ePrescriptionSelectedActivity['daily_amount'] ?? 0);
+
+        $exceededRecommended = $recommendedDailyDose > 0 && $dailyDose > $recommendedDailyDose;
+        $exceededPlan = $planDailyAmount > 0 && $dailyDose > $planDailyAmount;
+
+        if ($exceededRecommended || $exceededPlan) {
+            $this->ePrescriptionShowDailyDoseWarning = true;
+            return;
+        }
+
+        $this->submitEPrescriptionRequest();
+    }
+
+    public function submitEPrescriptionRequest(): void
+    {
+        try {
+            $uuids = [
+                'person_uuid' => $this->carePlan->person->uuid,
+                'encounter_uuid' => $this->carePlan->encounter?->uuid ?? null,
+                'employee_uuid' => Auth::user()?->activeDoctorEmployee()?->uuid,
+                'legal_entity_uuid' => Auth::user()?->activeDoctorEmployee()?->legalEntity?->uuid,
+            ];
+
+            $dbData = [
+                'uuid' => \Illuminate\Support\Str::uuid()->toString(),
+                'status' => 'draft',
+                'intent' => 'order',
+                'medication_id' => $this->ePrescriptionForm['medication_id'],
+                'medication_qty' => (float) $this->ePrescriptionForm['medication_qty'],
+                'medication_program_id' => $this->ePrescriptionForm['program_id'] ?: null,
+                'based_on_uuid' => $this->ePrescriptionSelectedActivity['uuid'],
+                'note' => $this->ePrescriptionForm['signature_text'],
+                'dosage_instructions' => [
+                    [
+                        'sequence' => 1,
+                        'text' => $this->ePrescriptionForm['signature_text'],
+                        'as_needed_boolean' => false,
+                        'route' => 'oral',
+                        'dose_and_rate' => [
+                            [
+                                'dose_quantity_value' => (float) $this->ePrescriptionForm['max_dose_per_administration'],
+                                'dose_quantity_unit' => $this->ePrescriptionForm['medication_unit']
+                            ]
+                        ],
+                        'max_dose_per_period' => $this->ePrescriptionForm['max_dose_per_period'],
+                        'max_dose_per_administration' => $this->ePrescriptionForm['max_dose_per_administration'],
+                    ]
+                ],
+                'started_at' => convertToYmd($this->ePrescriptionForm['started_at']),
+                'ended_at' => convertToYmd($this->ePrescriptionForm['ended_at']),
+                'inform_with' => $this->ePrescriptionForm['inform_with'],
+            ];
+
+            $mapper = new \App\Services\MedicalEvents\Mappers\MedicationRequestMapper();
+            $fhirPayload = $mapper->toFhir($dbData, $uuids);
+            
+            $informWithId = explode('|', $this->ePrescriptionForm['inform_with'])[0];
+            $fhirPayload['inform_with'] = [
+                'identifier' => [
+                    'value' => $informWithId
+                ]
+            ];
+
+            $response = EHealth::medicationRequest()->createRequest($this->carePlan->person->uuid, $fhirPayload);
+            $responseData = $response->getData();
+
+            $dbData['employee_id'] = Auth::user()?->activeDoctorEmployee()?->id;
+            $dbData['division_id'] = Auth::user()?->activeDoctorEmployee()?->division_id ?? null;
+            $dbData['based_on_id'] = $this->ePrescriptionSelectedActivity['id'];
+            $dbData['context_id'] = $this->carePlan->encounter?->id ?? null;
+            $dbData['request_number'] = $responseData['request_number'] ?? null;
+            $dbData['status'] = $responseData['status'] ?? 'NEW';
+            $dbData['uuid'] = $responseData['id'] ?? $dbData['uuid'];
+
+            \App\Repositories\MedicalEvents\Repository::medicationRequest()->store($dbData, $this->carePlan->person_id);
+
+            $this->showEPrescriptionDrawer = false;
+            $this->ePrescriptionRequestIdToSign = $dbData['uuid'];
+            $this->openSignatureModal('sign_eprescription');
+
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to create ePrescription: ' . $e->getMessage());
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Не вдалося створити заявку на рецепт: ' . $e->getMessage()]);
+        }
+    }
+
+    public function signEPrescription(): void
+    {
+        if (empty($this->ePrescriptionRequestIdToSign)) {
+            Session::flash('error', 'Не вибрано заявку на рецепт для підписання');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        $requestRecord = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::where('uuid', $this->ePrescriptionRequestIdToSign)->first();
+        if (!$requestRecord) {
+            Session::flash('error', 'Заявку на рецепт не знайдено');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        try {
+            $uuids = [
+                'person_uuid' => $this->carePlan->person->uuid,
+                'encounter_uuid' => $this->carePlan->encounter?->uuid ?? null,
+                'employee_uuid' => Auth::user()?->activeDoctorEmployee()?->uuid,
+                'legal_entity_uuid' => Auth::user()?->activeDoctorEmployee()?->legalEntity?->uuid,
+            ];
+
+            $dbData = $requestRecord->toArray();
+            $dbData['dosage_instructions'] = $requestRecord->dosageInstructions()->get()->toArray();
+            
+            $dbData['dosage_instructions'] = array_map(function($inst) {
+                if (is_string($inst['timing'])) {
+                    $inst['timing'] = json_decode($inst['timing'], true);
+                }
+                if (is_string($inst['dose_and_rate'])) {
+                    $inst['dose_and_rate'] = json_decode($inst['dose_and_rate'], true);
+                }
+                return $inst;
+            }, $dbData['dosage_instructions']);
+
+            $activity = \App\Models\CarePlanActivity::find($requestRecord->based_on_id);
+            $dbData['based_on_uuid'] = $activity?->uuid;
+
+            $mapper = new \App\Services\MedicalEvents\Mappers\MedicationRequestMapper();
+            $fhirPayload = $mapper->toFhir($dbData, $uuids);
+            
+            $informWithVal = $requestRecord->inform_with ?? '';
+            $informWithId = explode('|', $informWithVal)[0] ?? '';
+            $fhirPayload['inform_with'] = [
+                'identifier' => [
+                    'value' => $informWithId
+                ]
+            ];
+
+            $signedContent = signatureService()->signData(
+                Arr::toSnakeCase($fhirPayload),
+                $this->form['password'],
+                $this->form['knedp'],
+                $this->form['keyContainerUpload'],
+                Auth::user()->party->taxId
+            );
+
+            $eHealthResponse = EHealth::medicationRequest()->signRequest(
+                $this->carePlan->person->uuid,
+                $requestRecord->uuid,
+                [
+                    'signed_data'          => $signedContent,
+                    'signed_data_encoding' => 'base64',
+                ]
+            );
+
+            $responseData = $eHealthResponse->getData();
+            $finalResponse = $responseData;
+            
+            if (isset($responseData['links'][0]['href']) && str_contains($responseData['links'][0]['href'], '/jobs/')) {
+                $jobId = str_replace('/jobs/', '', $responseData['links'][0]['href']);
+                $jobApi = new \App\Classes\eHealth\Api\Job();
+                $attempts = 0;
+                do {
+                    sleep(2);
+                    $finalResponse = $jobApi->getDetails($jobId)->getData();
+                    $attempts++;
+                } while ($finalResponse['status'] === 'pending' && $attempts < 15);
+            }
+
+            if (($finalResponse['status'] ?? null) === 'failed') {
+                throw new EHealthValidationException($finalResponse);
+            }
+
+            $entity = isset($finalResponse['result'][0]) ? ($finalResponse['result'][0] ?? $finalResponse['result']) : $finalResponse;
+            $requestNumber = $entity['request_number'] ?? $requestRecord->request_number;
+            $finalStatus = $entity['status'] ?? 'active';
+
+            $requestRecord->update([
+                'status' => $finalStatus,
+                'request_number' => $requestNumber,
+            ]);
+
+            // Update CarePlanActivity status to 'in-progress' if it is 'scheduled'
+            if ($activity && $activity->status === 'scheduled') {
+                $activity->update(['status' => 'in-progress']);
+            }
+
+            $remainingQty = $this->ePrescriptionRemainingQty - $requestRecord->medication_qty;
+            if ($remainingQty < $requestRecord->medication_qty) {
+                $this->dispatch('flashMessage', [
+                    'type' => 'warning',
+                    'message' => "Увага! Для пацієнта в плані лікування залишалось лікарського засобу в кількості " . $this->ePrescriptionRemainingQty . " " . ($dbData['dosage_instructions'][0]['dose_and_rate'][0]['dose_quantity_unit'] ?? '') . ". Повідомте пацієнту, що для подальшого отримання ліків необхідно звернутись до лікаря для коригування плану."
+                ]);
+            }
+
+            $authMethodName = explode('|', $informWithVal)[1] ?? 'OTP';
+            $phoneNumber = explode('|', $informWithVal)[2] ?? '';
+
+            if (strtoupper($authMethodName) === 'OTP' || strtoupper($authMethodName) === 'THIRD_PERSON') {
+                $successMsg = "Електронний рецепт № {$requestNumber} створено в електронній системі охорони здоров’я. Номер рецепта та код погашення надіслано в СМС-повідомленні на номер {$phoneNumber}. Не забудьте попередити про це пацієнта! При необхідності роздрукуйте інформаційну пам’ятку пацієнту.";
+            } else {
+                $successMsg = "Електронний рецепт № {$requestNumber} створено в електронній системі охорони здоров’я. Код погашення зазначено в друкованій інформаційній пам’ятці. Не забудьте повідомити дані пацієнту та обов`язково роздрукувати інформаційну пам’ятку з кодом погашення!";
+            }
+
+            Session::flash('success', $successMsg);
+            $this->showSignatureModal = false;
+            $this->refreshCarePlan();
+
+        } catch (EHealthValidationException $e) {
+            $translatedMsg = $e->getTranslatedMessage();
+            Log::error('CarePlanShow: failed to sign E-Prescription validation: ' . $translatedMsg);
+            Session::flash('error', $translatedMsg);
+            $this->showSignatureModal = false;
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to sign E-Prescription: ' . $e->getMessage());
+            Session::flash('error', 'Помилка при підписанні рецепту: ' . $e->getMessage());
+            $this->showSignatureModal = false;
+        }
+    }
+
+    public function cancelPrescription(string $requestId): void
+    {
+        $requestRecord = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::where('uuid', $requestId)->first();
+        if (!$requestRecord) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Рецепт не знайдено']);
+            return;
+        }
+
+        $this->openSignatureModal('cancel_prescription', null, $requestId);
+    }
+
+    public function signCancelPrescription(): void
+    {
+        if (empty($this->ePrescriptionRequestIdToSign)) {
+            Session::flash('error', 'Не вибрано рецепт для скасування');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        $requestRecord = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::where('uuid', $this->ePrescriptionRequestIdToSign)->first();
+        if (!$requestRecord) {
+            Session::flash('error', 'Рецепт не знайдено');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        try {
+            $payload = [
+                'status_reason' => [
+                    'coding' => [
+                        [
+                            'system' => 'eHealth/care_plan_cancel_reasons',
+                            'code' => $this->statusReason ?: 'entered-in-error'
+                        ]
+                    ]
+                ]
+            ];
+
+            $signedContent = signatureService()->signData(
+                Arr::toSnakeCase($payload),
+                $this->form['password'],
+                $this->form['knedp'],
+                $this->form['keyContainerUpload'],
+                Auth::user()->party->taxId
+            );
+
+            $response = EHealth::medicationRequest()->cancel($this->carePlan->person->uuid, $requestRecord->uuid, [
+                'signed_data'          => $signedContent,
+                'signed_data_encoding' => 'base64',
+                'status_reason'        => $payload['status_reason'],
+            ]);
+
+            if ($response->successful()) {
+                $requestRecord->update(['status' => 'cancelled']);
+                $this->showSignatureModal = false;
+                $this->refreshCarePlan();
+                $this->dispatch('flashMessage', ['type' => 'success', 'message' => 'Електронний рецепт успішно скасовано.']);
+            } else {
+                throw new \Exception(json_encode($response->getData()));
+            }
+        } catch (EHealthValidationException $e) {
+            $translatedMsg = $e->getTranslatedMessage();
+            Log::error('CarePlanShow: failed to cancel prescription validation: ' . $translatedMsg);
+            Session::flash('error', $translatedMsg);
+            $this->showSignatureModal = false;
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to cancel prescription: ' . $e->getMessage());
+            Session::flash('error', 'Не вдалося скасувати рецепт: ' . $e->getMessage());
+            $this->showSignatureModal = false;
+        }
+    }
+
+    public function resendPrescriptionSms(string $prescriptionId): void
+    {
+        try {
+            $response = EHealth::medicationRequest()->resendOtp($this->carePlan->person->uuid, $prescriptionId);
+            if ($response->successful()) {
+                $this->dispatch('flashMessage', ['type' => 'success', 'message' => 'СМС з кодом погашення успішно надіслано повторно пацієнту.']);
+            } else {
+                $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Не вдалося повторно надіслати СМС: ' . json_encode($response->getData())]);
+            }
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to resend SMS: ' . $e->getMessage());
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Помилка надсилання СМС: ' . $e->getMessage()]);
+        }
+    }
+
+    public function loadPrintoutForm(string $prescriptionId): void
+    {
+        try {
+            $this->printableContent = "
+                <div style='font-family: sans-serif; padding: 40px; max-width: 600px; margin: 0 auto; border: 1px solid #ccc; border-radius: 8px;'>
+                    <h2 style='text-align: center; color: #1e3a8a;'>ІНФОРМАЦІЙНА ПАМ’ЯТКА ПАЦІЄНТА</h2>
+                    <p style='text-align: center; font-size: 14px; color: #555;'>Електронний рецепт № {$prescriptionId}</p>
+                    <hr style='border-top: 1px solid #eee; margin: 20px 0;'/>
+                    <table style='width: 100%; font-size: 14px; border-collapse: collapse;'>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Пацієнт:</td><td style='padding: 8px 0;'>{$this->carePlan->person->full_name}</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Лікарський засіб (МНН):</td><td style='padding: 8px 0;'>{$this->ePrescriptionSelectedProduct['name']}</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Код погашення:</td><td style='padding: 8px 0; font-size: 18px; font-weight: bold; color: #10b981;'>[Код в СМС / Доступний в аптеці]</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Сигнатура:</td><td style='padding: 8px 0;'>{$this->ePrescriptionForm['signature_text']}</td></tr>
+                    </table>
+                    <div style='margin-top: 40px; text-align: center; font-size: 12px; color: #888;'>
+                        Виписано в МІС. Дякуємо, що користуєтесь нашими послугами!
+                    </div>
+                </div>
+            ";
+            
+            $this->dispatch('printoutLoaded');
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to load printout form: ' . $e->getMessage());
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Не вдалося завантажити форму пам’ятки.']);
+        }
+    }
+
+    public function initReferralForm(int $activityId, CarePlanActivityRepository $activityRepository): void
+    {
+        $activity = $activityRepository->findById($activityId);
+        if (!$activity) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Призначення не знайдено']);
+            return;
+        }
+
+        $planStatus = strtolower(is_array($this->carePlan->status) 
+            ? ($this->carePlan->status['coding'][0]['code'] ?? ($this->carePlan->status['text'] ?? '')) 
+            : (string) $this->carePlan->status);
+        
+        $activityStatus = strtolower(is_array($activity->status) 
+            ? ($activity->status['coding'][0]['code'] ?? ($activity->status['text'] ?? '')) 
+            : (string) $activity->status);
+
+        $blockedPlanStatuses = ['cancelled', 'completed', 'terminated', 'entered-in-error'];
+        $blockedActivityStatuses = ['cancelled', 'completed'];
+
+        if (in_array($planStatus, $blockedPlanStatuses)) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Виписування направлення заборонено: план лікування завершено, скасовано або відмінено.']);
+            return;
+        }
+
+        if (in_array($activityStatus, $blockedActivityStatuses)) {
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Виписування направлення заборонено: це призначення вже завершено або скасовано.']);
+            return;
+        }
+
+        $this->referralWarningMessage = '';
+
+        // Calculate remaining quantity
+        $activityQty = (float) $activity->quantity;
+        
+        // Sum quantities of already issued requests
+        if ($activity->kind === 'service_request') {
+            $issuedQty = (float) \App\Models\MedicalEvents\Sql\ServiceRequestRequest::where('based_on_id', $activity->id)
+                ->where('status', '!=', 'entered-in-error')
+                ->sum('quantity');
+        } else {
+            $issuedQty = (float) \App\Models\MedicalEvents\Sql\DeviceRequestRequest::where('based_on_id', $activity->id)
+                ->where('status', '!=', 'entered-in-error')
+                ->sum('quantity');
+        }
+
+        $this->referralRemainingQty = max(0.0, $activityQty - $issuedQty);
+
+        $code = $activity->product_codeable_concept ?? $activity->product_reference ?? 'од.';
+
+        $supportingInfo = [];
+        $activity->reasonReferences()->get()->each(function ($identifier) use (&$supportingInfo) {
+            $typeCode = $identifier->type->first()?->coding?->first()?->code ?? 'condition';
+            $supportingInfo[] = [
+                'type' => $typeCode,
+                'uuid' => $identifier->value
+            ];
+        });
+
+        $this->referralForm = [
+            'activity_id' => $activity->id,
+            'kind' => $activity->kind,
+            'code' => $code,
+            'quantity' => min($this->referralRemainingQty, 1.0),
+            'started_at' => $activity->scheduled_period_start ? $activity->scheduled_period_start->format('d.m.Y') : now()->format('d.m.Y'),
+            'ended_at' => $activity->scheduled_period_end ? $activity->scheduled_period_end->format('d.m.Y') : now()->addMonths(3)->format('d.m.Y'),
+            'priority' => 'routine',
+            'intent' => 'order',
+            'category' => $activity->kind === 'service_request' ? 'procedure' : null,
+            'note' => '',
+            'program_id' => $activity->program ?? null,
+            'supporting_info' => $supportingInfo
+        ];
+
+        $this->referralShowRemainingQtyWarning = false;
+        $this->referralSelectedActivity = $activity->toArray();
+        $this->showReferralDrawer = true;
+    }
+
+    public function validateReferral(): void
+    {
+        $this->referralWarningMessage = '';
+        $this->referralShowRemainingQtyWarning = false;
+
+        $rules = [
+            'referralForm.started_at' => 'required|date_format:d.m.Y',
+            'referralForm.ended_at' => 'required|date_format:d.m.Y|after_or_equal:referralForm.started_at',
+            'referralForm.quantity' => 'required|numeric|min:0.01',
+            'referralForm.priority' => 'required|in:routine,urgent,asap,stat',
+        ];
+
+        if ($this->referralForm['kind'] === 'service_request') {
+            $rules['referralForm.category'] = 'required|string';
+        }
+
+        $this->validate($rules);
+
+        $qty = (float) $this->referralForm['quantity'];
+        if ($qty > $this->referralRemainingQty) {
+            $this->referralShowRemainingQtyWarning = true;
+            $this->referralWarningMessage = 'Кількість перевищує залишок за призначенням (' . $this->referralRemainingQty . ')';
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Кількість перевищує залишок за призначенням.']);
+            return;
+        }
+
+        // Propose to sign
+        $this->showReferralDrawer = false;
+        
+        $dbData = [
+            'uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'employee_id' => Auth::user()?->activeDoctorEmployee()?->id,
+            'person_id' => $this->carePlan->person_id,
+            'division_id' => Auth::user()?->activeDoctorEmployee()?->division_id ?? null,
+            'status' => 'draft',
+            'started_at' => convertToYmd($this->referralForm['started_at']),
+            'ended_at' => convertToYmd($this->referralForm['ended_at']),
+            'quantity' => $qty,
+            'program_id' => $this->referralForm['program_id'] ?? null,
+            'intent' => $this->referralForm['intent'] ?? 'order',
+            'category' => $this->referralForm['category'] ?? null,
+            'based_on_id' => $this->referralForm['activity_id'],
+            'context_id' => $this->carePlan->encounter?->id ?? null,
+            'priority' => $this->referralForm['priority'],
+            'note' => $this->referralForm['note'] ?? null,
+            'supporting_info' => $this->referralForm['supporting_info'] ?? null,
+        ];
+
+        $activity = \App\Models\CarePlanActivity::find($this->referralForm['activity_id']);
+
+        if ($this->referralForm['kind'] === 'service_request') {
+            $dbData['service_id'] = $activity->product_reference;
+            \App\Repositories\MedicalEvents\Repository::serviceRequest()->store($dbData, $this->carePlan->person_id);
+            $this->referralRequestIdToSign = $dbData['uuid'];
+            $this->openSignatureModal('sign_servicerequest');
+        } else {
+            $dbData['device_id'] = $activity->product_reference;
+            \App\Repositories\MedicalEvents\Repository::deviceRequest()->store($dbData, $this->carePlan->person_id);
+            $this->referralRequestIdToSign = $dbData['uuid'];
+            $this->openSignatureModal('sign_devicerequest');
+        }
+    }
+
+    public function signReferral(): void
+    {
+        if (empty($this->referralRequestIdToSign)) {
+            Session::flash('error', 'Не вибрано направлення для підписання');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        $kind = $this->actionType === 'sign_servicerequest' ? 'service_request' : 'device_request';
+
+        if ($kind === 'service_request') {
+            $requestRecord = \App\Models\MedicalEvents\Sql\ServiceRequestRequest::where('uuid', $this->referralRequestIdToSign)->first();
+        } else {
+            $requestRecord = \App\Models\MedicalEvents\Sql\DeviceRequestRequest::where('uuid', $this->referralRequestIdToSign)->first();
+        }
+
+        if (!$requestRecord) {
+            Session::flash('error', 'Направлення не знайдено');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        try {
+            $uuids = [
+                'person_uuid' => $this->carePlan->person->uuid,
+                'encounter_uuid' => $this->carePlan->encounter?->uuid ?? null,
+                'employee_uuid' => Auth::user()?->activeDoctorEmployee()?->uuid,
+                'legal_entity_uuid' => Auth::user()?->activeDoctorEmployee()?->legalEntity?->uuid,
+            ];
+
+            $dbData = $requestRecord->toArray();
+            $activity = \App\Models\CarePlanActivity::find($requestRecord->based_on_id);
+            $dbData['based_on_uuid'] = $activity?->uuid;
+
+            if ($kind === 'service_request') {
+                $mapper = new \App\Services\MedicalEvents\Mappers\ServiceRequestMapper();
+            } else {
+                $mapper = new \App\Services\MedicalEvents\Mappers\DeviceRequestMapper();
+            }
+
+            $fhirPayload = $mapper->toFhir($dbData, $uuids);
+
+            $signedContent = signatureService()->signData(
+                Arr::toSnakeCase($fhirPayload),
+                $this->form['password'],
+                $this->form['knedp'],
+                $this->form['keyContainerUpload'],
+                Auth::user()->party->taxId
+            );
+
+            if ($kind === 'service_request') {
+                $eHealthResponse = EHealth::serviceRequest()->signRequest(
+                    $this->carePlan->person->uuid,
+                    $requestRecord->uuid,
+                    [
+                        'signed_data'          => $signedContent,
+                        'signed_data_encoding' => 'base64',
+                    ]
+                );
+            } else {
+                $eHealthResponse = EHealth::deviceRequest()->signRequest(
+                    $this->carePlan->person->uuid,
+                    $requestRecord->uuid,
+                    [
+                        'signed_data'          => $signedContent,
+                        'signed_data_encoding' => 'base64',
+                    ]
+                );
+            }
+
+            $responseData = $eHealthResponse->getData();
+            $finalResponse = $responseData;
+            
+            if (isset($responseData['links'][0]['href']) && str_contains($responseData['links'][0]['href'], '/jobs/')) {
+                $jobId = str_replace('/jobs/', '', $responseData['links'][0]['href']);
+                $jobApi = new \App\Classes\eHealth\Api\Job();
+                $attempts = 0;
+                do {
+                    sleep(2);
+                    $finalResponse = $jobApi->getDetails($jobId)->getData();
+                    $attempts++;
+                } while (in_array($finalResponse['status'] ?? '', ['PENDING', 'PROCESSING']) && $attempts < 15);
+            }
+
+            if (($finalResponse['status'] ?? '') === 'ERROR') {
+                throw new \Exception($finalResponse['error']['message'] ?? 'Помилка обробки запиту в eHealth');
+            }
+
+            $dbData['status'] = $finalResponse['status'] ?? 'active';
+            $dbData['request_number'] = $finalResponse['request_number'] ?? ($finalResponse['requisition'] ?? null);
+            $dbData['uuid'] = $finalResponse['id'] ?? $dbData['uuid'];
+
+            if ($kind === 'service_request') {
+                \App\Repositories\MedicalEvents\Repository::serviceRequest()->store($dbData, $this->carePlan->person_id);
+            } else {
+                \App\Repositories\MedicalEvents\Repository::deviceRequest()->store($dbData, $this->carePlan->person_id);
+            }
+
+            // Update CarePlanActivity status to 'in-progress' if it is 'scheduled'
+            if ($activity && $activity->status === 'scheduled') {
+                $activity->update(['status' => 'in-progress']);
+            }
+
+            $this->showSignatureModal = false;
+            $this->dispatch('flashMessage', ['type' => 'success', 'message' => 'Направлення успішно створено та підписано в eHealth.']);
+            $this->refreshCarePlan();
+
+        } catch (EHealthValidationException $e) {
+            $translatedMsg = $e->getTranslatedMessage();
+            Log::error('CarePlanShow: failed to sign referral validation: ' . $translatedMsg);
+            Session::flash('error', $translatedMsg);
+            $this->showSignatureModal = false;
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to sign referral: ' . $e->getMessage());
+            Session::flash('error', 'Не вдалося підписати направлення: ' . $e->getMessage());
+            $this->showSignatureModal = false;
+        }
+    }
+
+    public function cancelReferral(string $requestId, string $kind): void
+    {
+        $this->openSignatureModal('cancel_referral', null, $requestId);
+    }
+
+    public function signCancelReferral(): void
+    {
+        if (empty($this->referralRequestIdToSign)) {
+            Session::flash('error', 'Не вибрано направлення для скасування');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        $service = \App\Models\MedicalEvents\Sql\ServiceRequestRequest::where('uuid', $this->referralRequestIdToSign)->first();
+        $device = null;
+        if (!$service) {
+            $device = \App\Models\MedicalEvents\Sql\DeviceRequestRequest::where('uuid', $this->referralRequestIdToSign)->first();
+        }
+
+        $record = $service ?: $device;
+        if (!$record) {
+            Session::flash('error', 'Направлення не знайдено');
+            $this->showSignatureModal = false;
+            return;
+        }
+
+        $kind = $service ? 'service_request' : 'device_request';
+
+        try {
+            $payload = [
+                'status_reason' => $this->statusReason ?: 'entered-in-error'
+            ];
+
+            $signedContent = signatureService()->signData(
+                Arr::toSnakeCase($payload),
+                $this->form['password'],
+                $this->form['knedp'],
+                $this->form['keyContainerUpload'],
+                Auth::user()->party->taxId
+            );
+
+            if ($kind === 'service_request') {
+                $response = EHealth::serviceRequest()->cancel($this->carePlan->person->uuid, $record->uuid, [
+                    'signed_data'          => $signedContent,
+                    'signed_data_encoding' => 'base64',
+                    'status_reason'        => $payload['status_reason'],
+                ]);
+            } else {
+                $response = EHealth::deviceRequest()->cancel($this->carePlan->person->uuid, $record->uuid, [
+                    'signed_data'          => $signedContent,
+                    'signed_data_encoding' => 'base64',
+                    'status_reason'        => $payload['status_reason'],
+                ]);
+            }
+
+            if ($response->successful()) {
+                $record->update(['status' => 'entered-in-error']);
+                $this->showSignatureModal = false;
+                $this->refreshCarePlan();
+                $this->dispatch('flashMessage', ['type' => 'success', 'message' => 'Направлення скасовано в eHealth.']);
+            } else {
+                throw new \Exception(json_encode($response->getData()));
+            }
+        } catch (EHealthValidationException $e) {
+            $translatedMsg = $e->getTranslatedMessage();
+            Log::error('CarePlanShow: failed to cancel referral validation: ' . $translatedMsg);
+            Session::flash('error', $translatedMsg);
+            $this->showSignatureModal = false;
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to cancel referral: ' . $e->getMessage());
+            Session::flash('error', 'Не вдалося скасувати направлення: ' . $e->getMessage());
+            $this->showSignatureModal = false;
+        }
+    }
+
+    public function loadReferralPrintoutForm(string $requestId): void
+    {
+        try {
+            $service = \App\Models\MedicalEvents\Sql\ServiceRequestRequest::where('uuid', $requestId)->first();
+            $device = null;
+            if (!$service) {
+                $device = \App\Models\MedicalEvents\Sql\DeviceRequestRequest::where('uuid', $requestId)->first();
+            }
+
+            $record = $service ?: $device;
+            if (!$record) {
+                $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Направлення не знайдено']);
+                return;
+            }
+
+            $code = $service ? $service->service_id : $device->device_id;
+            $name = $service ? "Направлення на послугу (ServiceRequest)" : "Направлення на виріб (DeviceRequest)";
+
+            $this->printableContent = "
+                <div style='font-family: sans-serif; padding: 40px; max-width: 600px; margin: 0 auto; border: 1px solid #ccc; border-radius: 8px;'>
+                    <h2 style='text-align: center; color: #1e3a8a;'>ІНФОРМАЦІЙНА ДОВІДКА НАПРАВЛЕННЯ</h2>
+                    <p style='text-align: center; font-size: 14px; color: #555;'>Електронне направлення № " . ($record->request_number ?: $record->uuid) . "</p>
+                    <hr style='border-top: 1px solid #eee; margin: 20px 0;'/>
+                    <table style='width: 100%; font-size: 14px; border-collapse: collapse;'>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Тип:</td><td style='padding: 8px 0;'>{$name}</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Пацієнт:</td><td style='padding: 8px 0;'>{$this->carePlan->person->full_name}</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Код послуги/виробу:</td><td style='padding: 8px 0;'>{$code}</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Кількість:</td><td style='padding: 8px 0;'>{$record->quantity} од.</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Термін дії:</td><td style='padding: 8px 0;'>з " . \Carbon\Carbon::parse($record->started_at)->format('d.m.Y') . " по " . \Carbon\Carbon::parse($record->ended_at)->format('d.m.Y') . "</td></tr>
+                        <tr><td style='padding: 8px 0; font-weight: bold;'>Примітки:</td><td style='padding: 8px 0;'>{$record->note}</td></tr>
+                    </table>
+                    <div style='margin-top: 40px; text-align: center; font-size: 12px; color: #888;'>
+                        Зверніться до будь-якого медичного закладу, що надає відповідні послуги за контрактом з НСЗУ.
+                    </div>
+                </div>
+            ";
+        } catch (\Exception $e) {
+            Log::error('CarePlanShow: failed to load referral printout: ' . $e->getMessage());
+            $this->dispatch('flashMessage', ['type' => 'error', 'message' => 'Не вдалося завантажити друковану форму.']);
+        }
     }
 
     private function cleanActivityPayload(array $payload): array

--- a/app/Livewire/CarePlan/CarePlanUpdate.php
+++ b/app/Livewire/CarePlan/CarePlanUpdate.php
@@ -220,7 +220,7 @@ class CarePlanUpdate extends CarePlanCreate
             // If it is an async job, poll it
             if (isset($responseData['links'][0]['href']) && str_contains($responseData['links'][0]['href'], '/jobs/')) {
                 $jobId = str_replace('/jobs/', '', $responseData['links'][0]['href']);
-                $jobApi = app(\App\Classes\eHealth\Api\Job::class);
+                $jobApi = EHealth::job();
                 $attempts = 0;
                 do {
                     sleep(2);

--- a/app/Models/MedicalEvents/Sql/DeviceRequestRequest.php
+++ b/app/Models/MedicalEvents/Sql/DeviceRequestRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\MedicalEvents\Sql;
+
+use Eloquence\Behaviours\HasCamelCasing;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Person\Person;
+use App\Models\Employee\Employee;
+use App\Models\CarePlanActivity;
+use App\Models\MedicalEvents\Sql\Encounter;
+
+class DeviceRequestRequest extends Model
+{
+    use HasCamelCasing;
+
+    protected $table = 'device_request_requests';
+
+    protected $fillable = [
+        'uuid',
+        'employee_id',
+        'person_id',
+        'division_id',
+        'status',
+        'request_number',
+        'started_at',
+        'ended_at',
+        'device_id',
+        'quantity',
+        'program_id',
+        'intent',
+        'category',
+        'based_on_id',
+        'context_id',
+        'priority',
+        'note',
+        'supporting_info'
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'ended_at' => 'datetime',
+        'quantity' => 'decimal:2',
+        'supporting_info' => 'array'
+    ];
+
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    public function basedOn(): BelongsTo
+    {
+        return $this->belongsTo(CarePlanActivity::class, 'based_on_id');
+    }
+
+    public function context(): BelongsTo
+    {
+        return $this->belongsTo(Encounter::class, 'context_id');
+    }
+}

--- a/app/Models/MedicalEvents/Sql/Medications/MedicationRequestRequest.php
+++ b/app/Models/MedicalEvents/Sql/Medications/MedicationRequestRequest.php
@@ -34,7 +34,8 @@ class MedicationRequestRequest extends Model
         'priority',
         'prior_prescription_id',
         'container_dosage',
-        'note'
+        'note',
+        'inform_with'
     ];
 
     public function dosageInstructions(): HasMany

--- a/app/Models/MedicalEvents/Sql/ServiceRequestRequest.php
+++ b/app/Models/MedicalEvents/Sql/ServiceRequestRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\MedicalEvents\Sql;
+
+use Eloquence\Behaviours\HasCamelCasing;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Person\Person;
+use App\Models\Employee\Employee;
+use App\Models\CarePlanActivity;
+use App\Models\MedicalEvents\Sql\Encounter;
+
+class ServiceRequestRequest extends Model
+{
+    use HasCamelCasing;
+
+    protected $table = 'service_request_requests';
+
+    protected $fillable = [
+        'uuid',
+        'employee_id',
+        'person_id',
+        'division_id',
+        'status',
+        'request_number',
+        'started_at',
+        'ended_at',
+        'service_id',
+        'quantity',
+        'program_id',
+        'intent',
+        'category',
+        'based_on_id',
+        'context_id',
+        'priority',
+        'note',
+        'supporting_info'
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'ended_at' => 'datetime',
+        'quantity' => 'decimal:2',
+        'supporting_info' => 'array'
+    ];
+
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function employee(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    public function basedOn(): BelongsTo
+    {
+        return $this->belongsTo(CarePlanActivity::class, 'based_on_id');
+    }
+
+    public function context(): BelongsTo
+    {
+        return $this->belongsTo(Encounter::class, 'context_id');
+    }
+}

--- a/app/Providers/MedicalEventsDBServiceProvider.php
+++ b/app/Providers/MedicalEventsDBServiceProvider.php
@@ -17,6 +17,9 @@ use App\Repositories\MedicalEvents\ObservationRepository;
 use App\Repositories\MedicalEvents\PaperReferralRepository;
 use App\Repositories\MedicalEvents\PeriodRepository;
 use App\Repositories\MedicalEvents\ProcedureRepository;
+use App\Repositories\MedicalEvents\MedicationRequestRepository;
+use App\Repositories\MedicalEvents\ServiceRequestRequestRepository;
+use App\Repositories\MedicalEvents\DeviceRequestRequestRepository;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use RuntimeException;
@@ -43,6 +46,16 @@ class MedicalEventsDBServiceProvider extends ServiceProvider implements Deferrab
         $this->bindRepository(PaperReferralRepository::class);
         $this->bindRepository(PeriodRepository::class);
         $this->bindRepository(ClinicalImpressionRepository::class);
+        $this->bindRepository(ServiceRequestRequestRepository::class);
+        $this->bindRepository(DeviceRequestRequestRepository::class);
+
+        $this->app->bind(MedicationRequestRepository::class, function () {
+            $driver = config('database.medical_events_db_driver', 'sql');
+            $modelClass = $driver === 'sql'
+                ? \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::class
+                : "App\\Models\\MedicalEvents\\Mongo\\Medications\\MedicationRequestRequest";
+            return new MedicationRequestRepository(new $modelClass());
+        });
     }
 
     /**
@@ -89,7 +102,10 @@ class MedicalEventsDBServiceProvider extends ServiceProvider implements Deferrab
             ProcedureRepository::class,
             PaperReferralRepository::class,
             PeriodRepository::class,
-            ClinicalImpressionRepository::class
+            ClinicalImpressionRepository::class,
+            MedicationRequestRepository::class,
+            ServiceRequestRequestRepository::class,
+            DeviceRequestRequestRepository::class
         ];
     }
 }

--- a/app/Repositories/MedicalEvents/DeviceRequestRequestRepository.php
+++ b/app/Repositories/MedicalEvents/DeviceRequestRequestRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\MedicalEvents;
+
+use App\Models\MedicalEvents\Sql\DeviceRequestRequest;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * @property DeviceRequestRequest $model
+ */
+class DeviceRequestRequestRepository extends BaseRepository
+{
+    /**
+     * Create or update device request request in DB for patient.
+     *
+     * @param  array  $data
+     * @param  int  $personId
+     * @return int
+     * @throws Throwable
+     */
+    public function store(array $data, int $personId): int
+    {
+        return DB::transaction(function () use ($data, $personId) {
+            $request = $this->model->updateOrCreate(
+                ['uuid' => $data['uuid'] ?? $data['id']],
+                [
+                    'employee_id' => $data['employee_id'],
+                    'person_id' => $personId,
+                    'division_id' => $data['division_id'] ?? null,
+                    'status' => $data['status'],
+                    'request_number' => $data['request_number'] ?? null,
+                    'started_at' => $data['started_at'] ?? null,
+                    'ended_at' => $data['ended_at'] ?? null,
+                    'device_id' => $data['device_id'],
+                    'quantity' => $data['quantity'] ?? 1,
+                    'program_id' => $data['program_id'] ?? null,
+                    'intent' => $data['intent'] ?? 'order',
+                    'category' => $data['category'] ?? null,
+                    'based_on_id' => $data['based_on_id'] ?? null,
+                    'context_id' => $data['context_id'] ?? null,
+                    'priority' => $data['priority'] ?? null,
+                    'note' => $data['note'] ?? null,
+                    'supporting_info' => $data['supporting_info'] ?? null,
+                ]
+            );
+
+            return (int) $request->id;
+        });
+    }
+
+    /**
+     * Get device request requests data related to the person.
+     *
+     * @param  int  $personId
+     * @return array
+     */
+    public function getByPersonId(int $personId): array
+    {
+        return $this->model
+            ->where('person_id', $personId)
+            ->get()
+            ->toArray();
+    }
+}

--- a/app/Repositories/MedicalEvents/MedicationRequestRepository.php
+++ b/app/Repositories/MedicalEvents/MedicationRequestRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\MedicalEvents;
+
+use App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * @property MedicationRequestRequest $model
+ */
+class MedicationRequestRepository extends BaseRepository
+{
+    /**
+     * Create medication request request in DB for patient with related dosage instructions.
+     *
+     * @param  array  $data
+     * @param  int  $personId
+     * @return int
+     * @throws Throwable
+     */
+    public function store(array $data, int $personId): int
+    {
+        return DB::transaction(function () use ($data, $personId) {
+            $request = $this->model->create([
+                'uuid' => $data['uuid'] ?? $data['id'],
+                'employee_id' => $data['employee_id'],
+                'person_id' => $personId,
+                'division_id' => $data['division_id'] ?? null,
+                'status' => $data['status'],
+                'request_number' => $data['request_number'] ?? null,
+                'started_at' => $data['started_at'] ?? null,
+                'ended_at' => $data['ended_at'] ?? null,
+                'medication_id' => $data['medication_id'],
+                'medication_qty' => $data['medication_qty'],
+                'medication_program_id' => $data['medication_program_id'] ?? null,
+                'intent' => $data['intent'] ?? 'order',
+                'category' => $data['category'] ?? null,
+                'based_on_id' => $data['based_on_id'] ?? null,
+                'context_id' => $data['context_id'] ?? null,
+                'priority' => $data['priority'] ?? null,
+                'prior_prescription_id' => $data['prior_prescription_id'] ?? null,
+                'container_dosage' => $data['container_dosage'] ?? null,
+                'note' => $data['note'] ?? null,
+            ]);
+
+            if (!empty($data['dosage_instructions'])) {
+                foreach ($data['dosage_instructions'] as $inst) {
+                    $instruction = $request->dosageInstructions()->create([
+                        'medication_request_id' => $inst['medication_request_id'] ?? null,
+                        'sequence' => $inst['sequence'] ?? null,
+                        'text' => $inst['text'] ?? null,
+                        'patient_instruction' => $inst['patient_instruction'] ?? null,
+                        'timing' => !empty($inst['timing']) ? json_encode($inst['timing']) : null,
+                        'as_needed_boolean' => $inst['as_needed_boolean'] ?? false,
+                        'route' => $inst['route'] ?? null,
+                        'method' => $inst['method'] ?? null,
+                        'dose_and_rate' => !empty($inst['dose_and_rate']) ? json_encode($inst['dose_and_rate']) : null,
+                        'max_dose_per_period' => $inst['max_dose_per_period'] ?? null,
+                        'max_dose_per_administration' => $inst['max_dose_per_administration'] ?? null,
+                        'max_dose_per_lifetime' => $inst['max_dose_per_lifetime'] ?? null,
+                    ]);
+
+                    if (!empty($inst['dose_and_rate'])) {
+                        foreach ($inst['dose_and_rate'] as $dr) {
+                            $instruction->doseRate()->create([
+                                'rate_ratio' => $dr['rate_ratio'] ?? null,
+                            ]);
+                        }
+                    }
+                }
+            }
+
+            return (int) $request->id;
+        });
+    }
+
+    /**
+     * Get medication request requests data that is related to the person.
+     *
+     * @param  int  $personId
+     * @return array
+     */
+    public function getByPersonId(int $personId): array
+    {
+        return $this->model
+            ->with(['dosageInstructions.doseRate'])
+            ->where('person_id', $personId)
+            ->get()
+            ->toArray();
+    }
+}

--- a/app/Repositories/MedicalEvents/Repository.php
+++ b/app/Repositories/MedicalEvents/Repository.php
@@ -70,4 +70,20 @@ final class Repository
     {
         return app(PeriodRepository::class);
     }
+
+    public static function medicationRequest(): MedicationRequestRepository
+    {
+        return app(MedicationRequestRepository::class);
+    }
+
+    public static function serviceRequest(): ServiceRequestRequestRepository
+    {
+        return app(ServiceRequestRequestRepository::class);
+    }
+
+    public static function deviceRequest(): DeviceRequestRequestRepository
+    {
+        return app(DeviceRequestRequestRepository::class);
+    }
 }
+

--- a/app/Repositories/MedicalEvents/ServiceRequestRequestRepository.php
+++ b/app/Repositories/MedicalEvents/ServiceRequestRequestRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\MedicalEvents;
+
+use App\Models\MedicalEvents\Sql\ServiceRequestRequest;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * @property ServiceRequestRequest $model
+ */
+class ServiceRequestRequestRepository extends BaseRepository
+{
+    /**
+     * Create or update service request request in DB for patient.
+     *
+     * @param  array  $data
+     * @param  int  $personId
+     * @return int
+     * @throws Throwable
+     */
+    public function store(array $data, int $personId): int
+    {
+        return DB::transaction(function () use ($data, $personId) {
+            $request = $this->model->updateOrCreate(
+                ['uuid' => $data['uuid'] ?? $data['id']],
+                [
+                    'employee_id' => $data['employee_id'],
+                    'person_id' => $personId,
+                    'division_id' => $data['division_id'] ?? null,
+                    'status' => $data['status'],
+                    'request_number' => $data['request_number'] ?? null,
+                    'started_at' => $data['started_at'] ?? null,
+                    'ended_at' => $data['ended_at'] ?? null,
+                    'service_id' => $data['service_id'],
+                    'quantity' => $data['quantity'] ?? 1,
+                    'program_id' => $data['program_id'] ?? null,
+                    'intent' => $data['intent'] ?? 'order',
+                    'category' => $data['category'] ?? null,
+                    'based_on_id' => $data['based_on_id'] ?? null,
+                    'context_id' => $data['context_id'] ?? null,
+                    'priority' => $data['priority'] ?? null,
+                    'note' => $data['note'] ?? null,
+                    'supporting_info' => $data['supporting_info'] ?? null,
+                ]
+            );
+
+            return (int) $request->id;
+        });
+    }
+
+    /**
+     * Get service request requests data related to the person.
+     *
+     * @param  int  $personId
+     * @return array
+     */
+    public function getByPersonId(int $personId): array
+    {
+        return $this->model
+            ->where('person_id', $personId)
+            ->get()
+            ->toArray();
+    }
+}

--- a/app/Services/MedicalEvents/Mappers/DeviceRequestMapper.php
+++ b/app/Services/MedicalEvents/Mappers/DeviceRequestMapper.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\MedicalEvents\Mappers;
+
+use App\Contracts\FhirMapperContract;
+use App\Services\MedicalEvents\FhirResource;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+
+class DeviceRequestMapper implements FhirMapperContract
+{
+    /**
+     * Convert database/form data to FHIR structure for eHealth API.
+     *
+     * @param  array  $data
+     * @param  mixed  ...$context [0] array $uuids (person_uuid, encounter_uuid, employee_uuid, legal_entity_uuid)
+     * @return array
+     */
+    public function toFhir(array $data, mixed ...$context): array
+    {
+        [$uuids] = $context;
+
+        $result = [
+            'id' => $data['uuid'] ?? Str::uuid()->toString(),
+            'status' => $data['status'] ?? 'draft',
+            'intent' => $data['intent'] ?? 'order',
+            'codeCodeableConcept' => FhirResource::make()
+                ->coding('eHealth/device_definitions', $data['device_id'])
+                ->toCodeableConcept(),
+            'subject' => FhirResource::make()
+                ->coding('eHealth/resources', 'patient')
+                ->toIdentifier($uuids['person_uuid']),
+            'requester' => [
+                'agent' => FhirResource::make()
+                    ->coding('eHealth/resources', 'employee')
+                    ->toIdentifier($uuids['employee_uuid']),
+                'onBehalfOf' => FhirResource::make()
+                    ->coding('eHealth/resources', 'legal_entity')
+                    ->toIdentifier($uuids['legal_entity_uuid'])
+            ]
+        ];
+
+        if (!empty($uuids['encounter_uuid'])) {
+            $result['context'] = FhirResource::make()
+                ->coding('eHealth/resources', 'encounter')
+                ->toIdentifier($uuids['encounter_uuid']);
+        }
+
+        if (!empty($data['based_on_uuid'])) {
+            $result['basedOn'] = [
+                FhirResource::make()
+                    ->coding('eHealth/resources', 'care_plan_activity')
+                    ->toIdentifier($data['based_on_uuid'])
+            ];
+        }
+
+        if (!empty($data['priority'])) {
+            $result['priority'] = $data['priority'];
+        }
+
+        if (!empty($data['note'])) {
+            $result['note'] = [['text' => $data['note']]];
+        }
+
+        if (!empty($data['program_id'])) {
+            $result['program'] = FhirResource::make()
+                ->coding('eHealth/medical_programs', $data['program_id'])
+                ->toIdentifier($data['program_id']);
+        }
+
+        if (isset($data['quantity'])) {
+            $result['quantityInteger'] = (int) $data['quantity'];
+        }
+
+        if (!empty($data['started_at']) || !empty($data['ended_at'])) {
+            $result['occurrencePeriod'] = [
+                'start' => $data['started_at'] ? CarbonImmutable::parse($data['started_at'])->toIso8601String() : null,
+                'end' => $data['ended_at'] ? CarbonImmutable::parse($data['ended_at'])->toIso8601String() : null,
+            ];
+            $result['occurrencePeriod'] = array_filter($result['occurrencePeriod']);
+        }
+
+        if (!empty($data['supporting_info'])) {
+            $result['supportingInfo'] = [];
+            foreach ($data['supporting_info'] as $ref) {
+                if (!empty($ref['uuid']) && !empty($ref['type'])) {
+                    $result['supportingInfo'][] = FhirResource::make()
+                        ->coding('eHealth/resources', strtolower($ref['type']))
+                        ->toIdentifier($ref['uuid']);
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert FHIR structure (from eHealth) to flat application format.
+     */
+    public function fromFhir(array $data, mixed ...$context): array
+    {
+        $supportingInfo = [];
+        if (!empty($data['supportingInfo'])) {
+            foreach ($data['supportingInfo'] as $si) {
+                $supportingInfo[] = [
+                    'uuid' => data_get($si, 'identifier.value'),
+                    'type' => data_get($si, 'identifier.type.coding.0.code'),
+                ];
+            }
+        }
+
+        return [
+            'uuid' => data_get($data, 'uuid') ?? data_get($data, 'id'),
+            'status' => data_get($data, 'status'),
+            'request_number' => data_get($data, 'requestNumber') ?? data_get($data, 'request_number'),
+            'started_at' => data_get($data, 'occurrencePeriod.start') ?? data_get($data, 'started_at'),
+            'ended_at' => data_get($data, 'occurrencePeriod.end') ?? data_get($data, 'ended_at'),
+            'device_id' => data_get($data, 'codeCodeableConcept.coding.0.code'),
+            'quantity' => data_get($data, 'quantityInteger'),
+            'program_id' => data_get($data, 'program.identifier.value'),
+            'intent' => data_get($data, 'intent'),
+            'category' => data_get($data, 'category.0.coding.0.code'),
+            'based_on_uuid' => data_get($data, 'basedOn.0.identifier.value'),
+            'context_uuid' => data_get($data, 'context.identifier.value'),
+            'priority' => data_get($data, 'priority'),
+            'note' => data_get($data, 'note.0.text'),
+            'supporting_info' => $supportingInfo
+        ];
+    }
+}

--- a/app/Services/MedicalEvents/Mappers/MedicationRequestMapper.php
+++ b/app/Services/MedicalEvents/Mappers/MedicationRequestMapper.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\MedicalEvents\Mappers;
+
+use App\Contracts\FhirMapperContract;
+use App\Services\MedicalEvents\FhirResource;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+
+class MedicationRequestMapper implements FhirMapperContract
+{
+    /**
+     * Convert flat database/form data to FHIR structure for eHealth API.
+     *
+     * @param  array  $data
+     * @param  mixed  ...$context [0] array $uuids (person_uuid, encounter_uuid, employee_uuid, legal_entity_uuid)
+     * @return array
+     */
+    public function toFhir(array $data, mixed ...$context): array
+    {
+        [$uuids] = $context;
+
+        $result = [
+            'id' => $data['uuid'] ?? Str::uuid()->toString(),
+            'status' => $data['status'] ?? 'draft',
+            'intent' => $data['intent'] ?? 'order',
+            'medicationCodeableConcept' => FhirResource::make()
+                ->coding('eHealth/medications', $data['medication_id'])
+                ->toCodeableConcept(),
+            'subject' => FhirResource::make()
+                ->coding('eHealth/resources', 'patient')
+                ->toIdentifier($uuids['person_uuid']),
+            'requester' => [
+                'agent' => FhirResource::make()
+                    ->coding('eHealth/resources', 'employee')
+                    ->toIdentifier($uuids['employee_uuid']),
+                'onBehalfOf' => FhirResource::make()
+                    ->coding('eHealth/resources', 'legal_entity')
+                    ->toIdentifier($uuids['legal_entity_uuid'])
+            ]
+        ];
+
+        if (!empty($uuids['encounter_uuid'])) {
+            $result['context'] = FhirResource::make()
+                ->coding('eHealth/resources', 'encounter')
+                ->toIdentifier($uuids['encounter_uuid']);
+        }
+
+        if (!empty($data['based_on_uuid'])) {
+            $result['basedOn'] = [
+                FhirResource::make()
+                    ->coding('eHealth/resources', 'care_plan_activity')
+                    ->toIdentifier($data['based_on_uuid'])
+            ];
+        }
+
+        if (!empty($data['category'])) {
+            $result['category'] = FhirResource::make()
+                ->coding('eHealth/medication_request_categories', $data['category'])
+                ->toCodeableConcept();
+        }
+
+        if (!empty($data['priority'])) {
+            $result['priority'] = $data['priority'];
+        }
+
+        if (!empty($data['note'])) {
+            $result['note'] = [['text' => $data['note']]];
+        }
+
+        if (!empty($data['medication_program_id'])) {
+            $result['program'] = FhirResource::make()
+                ->coding('eHealth/medical_programs', $data['medication_program_id'])
+                ->toIdentifier($data['medication_program_id']);
+        }
+
+        // Mapping Dosage Instructions
+        if (!empty($data['dosage_instructions'])) {
+            $result['dosageInstruction'] = array_map(function (array $inst, int $index) {
+                $dosage = [
+                    'sequence' => $inst['sequence'] ?? ($index + 1),
+                    'text' => $inst['text'] ?? null,
+                    'patientInstruction' => $inst['patient_instruction'] ?? null,
+                ];
+
+                if (!empty($inst['additional_instruction_code'])) {
+                    $dosage['additionalInstruction'] = [
+                        FhirResource::make()
+                            ->coding('eHealth/additional_dosage_instructions', $inst['additional_instruction_code'])
+                            ->toCodeableConcept()
+                    ];
+                }
+
+                if (!empty($inst['timing'])) {
+                    $dosage['timing'] = $inst['timing'];
+                }
+
+                if (isset($inst['as_needed_boolean'])) {
+                    $dosage['asNeededBoolean'] = (bool) $inst['as_needed_boolean'];
+                }
+
+                if (!empty($inst['route'])) {
+                    $dosage['route'] = FhirResource::make()
+                        ->coding('eHealth/vaccination_routes', $inst['route'])
+                        ->toCodeableConcept();
+                }
+
+                if (!empty($inst['method'])) {
+                    $dosage['method'] = FhirResource::make()
+                        ->coding('eHealth/dosage_methods', $inst['method'])
+                        ->toCodeableConcept();
+                }
+
+                // Dose and Rate mapping
+                if (!empty($inst['dose_and_rate'])) {
+                    $dosage['doseAndRate'] = array_map(function (array $dr) {
+                        $mappedDr = [];
+                        if (isset($dr['dose_quantity_value'])) {
+                            $mappedDr['doseQuantity'] = [
+                                'value' => (float) $dr['dose_quantity_value'],
+                                'unit' => $dr['dose_quantity_unit'] ?? null,
+                                'system' => 'http://unitsofmeasure.org',
+                                'code' => $dr['dose_quantity_code'] ?? null
+                            ];
+                        }
+                        return $mappedDr;
+                    }, $inst['dose_and_rate']);
+                }
+
+                return array_filter($dosage, fn ($val) => $val !== null);
+            }, $data['dosage_instructions'], array_keys($data['dosage_instructions']));
+        }
+
+        // Dispense request quantity mapping
+        if (isset($data['medication_qty'])) {
+            $result['dispenseRequest'] = [
+                'quantity' => [
+                    'value' => (float) $data['medication_qty'],
+                    'system' => 'http://unitsofmeasure.org'
+                ]
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert FHIR structure (from eHealth response/DB) to flat application format.
+     *
+     * @param  array  $data
+     * @param  mixed  ...$context
+     * @return array
+     */
+    public function fromFhir(array $data, mixed ...$context): array
+    {
+        $dosageInstructions = [];
+        if (!empty($data['dosageInstruction'])) {
+            foreach ($data['dosageInstruction'] as $inst) {
+                $doseAndRate = [];
+                if (!empty($inst['doseAndRate'])) {
+                    foreach ($inst['doseAndRate'] as $dr) {
+                        $doseAndRate[] = [
+                            'dose_quantity_value' => data_get($dr, 'doseQuantity.value'),
+                            'dose_quantity_unit' => data_get($dr, 'doseQuantity.unit'),
+                            'dose_quantity_code' => data_get($dr, 'doseQuantity.code')
+                        ];
+                    }
+                }
+
+                $dosageInstructions[] = [
+                    'sequence' => data_get($inst, 'sequence'),
+                    'text' => data_get($inst, 'text'),
+                    'patient_instruction' => data_get($inst, 'patientInstruction'),
+                    'additional_instruction_code' => data_get($inst, 'additionalInstruction.0.coding.0.code'),
+                    'timing' => data_get($inst, 'timing'),
+                    'as_needed_boolean' => data_get($inst, 'asNeededBoolean', false),
+                    'route' => data_get($inst, 'route.coding.0.code'),
+                    'method' => data_get($inst, 'method.coding.0.code'),
+                    'dose_and_rate' => $doseAndRate
+                ];
+            }
+        }
+
+        return [
+            'uuid' => data_get($data, 'uuid') ?? data_get($data, 'id'),
+            'status' => data_get($data, 'status'),
+            'request_number' => data_get($data, 'requestNumber') ?? data_get($data, 'request_number'),
+            'started_at' => data_get($data, 'period.start') ?? data_get($data, 'started_at'),
+            'ended_at' => data_get($data, 'period.end') ?? data_get($data, 'ended_at'),
+            'medication_id' => data_get($data, 'medicationCodeableConcept.coding.0.code'),
+            'medication_qty' => data_get($data, 'dispenseRequest.quantity.value'),
+            'medication_program_id' => data_get($data, 'program.identifier.value'),
+            'intent' => data_get($data, 'intent'),
+            'category' => data_get($data, 'category.coding.0.code'),
+            'based_on_uuid' => data_get($data, 'basedOn.0.identifier.value'),
+            'context_uuid' => data_get($data, 'context.identifier.value'),
+            'priority' => data_get($data, 'priority'),
+            'note' => data_get($data, 'note.0.text'),
+            'dosage_instructions' => $dosageInstructions
+        ];
+    }
+}

--- a/app/Services/MedicalEvents/Mappers/ServiceRequestMapper.php
+++ b/app/Services/MedicalEvents/Mappers/ServiceRequestMapper.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\MedicalEvents\Mappers;
+
+use App\Contracts\FhirMapperContract;
+use App\Services\MedicalEvents\FhirResource;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+
+class ServiceRequestMapper implements FhirMapperContract
+{
+    /**
+     * Convert database/form data to FHIR structure for eHealth API.
+     *
+     * @param  array  $data
+     * @param  mixed  ...$context [0] array $uuids (person_uuid, encounter_uuid, employee_uuid, legal_entity_uuid)
+     * @return array
+     */
+    public function toFhir(array $data, mixed ...$context): array
+    {
+        [$uuids] = $context;
+
+        $result = [
+            'id' => $data['uuid'] ?? Str::uuid()->toString(),
+            'status' => $data['status'] ?? 'draft',
+            'intent' => $data['intent'] ?? 'order',
+            'code' => FhirResource::make()
+                ->coding('eHealth/services', $data['service_id'])
+                ->toCodeableConcept(),
+            'subject' => FhirResource::make()
+                ->coding('eHealth/resources', 'patient')
+                ->toIdentifier($uuids['person_uuid']),
+            'requester' => [
+                'agent' => FhirResource::make()
+                    ->coding('eHealth/resources', 'employee')
+                    ->toIdentifier($uuids['employee_uuid']),
+                'onBehalfOf' => FhirResource::make()
+                    ->coding('eHealth/resources', 'legal_entity')
+                    ->toIdentifier($uuids['legal_entity_uuid'])
+            ]
+        ];
+
+        if (!empty($uuids['encounter_uuid'])) {
+            $result['context'] = FhirResource::make()
+                ->coding('eHealth/resources', 'encounter')
+                ->toIdentifier($uuids['encounter_uuid']);
+        }
+
+        if (!empty($data['based_on_uuid'])) {
+            $result['basedOn'] = [
+                FhirResource::make()
+                    ->coding('eHealth/resources', 'care_plan_activity')
+                    ->toIdentifier($data['based_on_uuid'])
+            ];
+        }
+
+        if (!empty($data['category'])) {
+            $result['category'] = [
+                FhirResource::make()
+                    ->coding('eHealth/service_request_categories', $data['category'])
+                    ->toCodeableConcept()
+            ];
+        }
+
+        if (!empty($data['priority'])) {
+            $result['priority'] = $data['priority'];
+        }
+
+        if (!empty($data['note'])) {
+            $result['note'] = [['text' => $data['note']]];
+        }
+
+        if (!empty($data['program_id'])) {
+            $result['program'] = FhirResource::make()
+                ->coding('eHealth/medical_programs', $data['program_id'])
+                ->toIdentifier($data['program_id']);
+        }
+
+        if (isset($data['quantity'])) {
+            $result['quantityInteger'] = (int) $data['quantity'];
+        }
+
+        if (!empty($data['started_at']) || !empty($data['ended_at'])) {
+            $result['occurrencePeriod'] = [
+                'start' => $data['started_at'] ? CarbonImmutable::parse($data['started_at'])->toIso8601String() : null,
+                'end' => $data['ended_at'] ? CarbonImmutable::parse($data['ended_at'])->toIso8601String() : null,
+            ];
+            $result['occurrencePeriod'] = array_filter($result['occurrencePeriod']);
+        }
+
+        if (!empty($data['supporting_info'])) {
+            $result['supportingInfo'] = [];
+            foreach ($data['supporting_info'] as $ref) {
+                if (!empty($ref['uuid']) && !empty($ref['type'])) {
+                    $result['supportingInfo'][] = FhirResource::make()
+                        ->coding('eHealth/resources', strtolower($ref['type']))
+                        ->toIdentifier($ref['uuid']);
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Convert FHIR structure (from eHealth) to flat application format.
+     */
+    public function fromFhir(array $data, mixed ...$context): array
+    {
+        $supportingInfo = [];
+        if (!empty($data['supportingInfo'])) {
+            foreach ($data['supportingInfo'] as $si) {
+                $supportingInfo[] = [
+                    'uuid' => data_get($si, 'identifier.value'),
+                    'type' => data_get($si, 'identifier.type.coding.0.code'),
+                ];
+            }
+        }
+
+        return [
+            'uuid' => data_get($data, 'uuid') ?? data_get($data, 'id'),
+            'status' => data_get($data, 'status'),
+            'request_number' => data_get($data, 'requestNumber') ?? data_get($data, 'request_number'),
+            'started_at' => data_get($data, 'occurrencePeriod.start') ?? data_get($data, 'started_at'),
+            'ended_at' => data_get($data, 'occurrencePeriod.end') ?? data_get($data, 'ended_at'),
+            'service_id' => data_get($data, 'code.coding.0.code'),
+            'quantity' => data_get($data, 'quantityInteger'),
+            'program_id' => data_get($data, 'program.identifier.value'),
+            'intent' => data_get($data, 'intent'),
+            'category' => data_get($data, 'category.0.coding.0.code'),
+            'based_on_uuid' => data_get($data, 'basedOn.0.identifier.value'),
+            'context_uuid' => data_get($data, 'context.identifier.value'),
+            'priority' => data_get($data, 'priority'),
+            'note' => data_get($data, 'note.0.text'),
+            'supporting_info' => $supportingInfo
+        ];
+    }
+}

--- a/database/migrations/update/0_1/2026_06_01_000001_create_medication_requests_tables.php
+++ b/database/migrations/update/0_1/2026_06_01_000001_create_medication_requests_tables.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 1. dosages table (for Dose model)
+        if (!Schema::hasTable('dosages')) {
+            Schema::create('dosages', static function (Blueprint $table) {
+                $table->id();
+                $table->decimal('value', 15, 4)->nullable();
+                $table->string('unit')->nullable();
+                $table->string('system')->nullable();
+                $table->string('code')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        // 2. medication_request_requests table
+        if (!Schema::hasTable('medication_request_requests')) {
+            Schema::create('medication_request_requests', static function (Blueprint $table) {
+                $table->id();
+                $table->uuid('uuid')->unique();
+                $table->foreignId('employee_id')->constrained('employees');
+                $table->foreignId('person_id')->constrained('persons');
+                $table->foreignId('division_id')->nullable()->constrained('divisions');
+                $table->string('status');
+                $table->string('request_number')->nullable();
+                $table->timestamp('started_at')->nullable();
+                $table->timestamp('ended_at')->nullable();
+                $table->string('medication_id'); // INN-based or product code
+                $table->decimal('medication_qty', 15, 2);
+                $table->string('medication_program_id')->nullable();
+                $table->string('intent');
+                $table->string('category')->nullable();
+                $table->foreignId('based_on_id')->nullable()->constrained('care_plan_activities');
+                $table->foreignId('context_id')->nullable()->constrained('encounters');
+                $table->string('priority')->nullable();
+                $table->foreignId('prior_prescription_id')->nullable()->constrained('medication_request_requests');
+                $table->string('container_dosage')->nullable();
+                $table->text('note')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        // 3. dosage_instructions table
+        if (!Schema::hasTable('dosage_instructions')) {
+            Schema::create('dosage_instructions', static function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('medication_request_request_id')->constrained('medication_request_requests')->cascadeOnDelete();
+                $table->string('medication_request_id')->nullable(); // UUID of final MedicationRequest from eHealth
+                $table->integer('sequence')->nullable();
+                $table->text('text')->nullable();
+                $table->foreignId('additional_instruction_id')->nullable()->constrained('codeable_concepts');
+                $table->text('patient_instruction')->nullable();
+                $table->text('timing')->nullable();
+                $table->boolean('as_needed_boolean')->default(false);
+                $table->foreignId('site_id')->nullable()->constrained('codeable_concepts');
+                $table->string('route')->nullable();
+                $table->string('method')->nullable();
+                $table->text('dose_and_rate')->nullable();
+                $table->string('max_dose_per_period')->nullable();
+                $table->string('max_dose_per_administration')->nullable();
+                $table->string('max_dose_per_lifetime')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        // 4. dose_rates table
+        if (!Schema::hasTable('dose_rates')) {
+            Schema::create('dose_rates', static function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('dosage_instruction_id')->nullable()->constrained('dosage_instructions')->cascadeOnDelete();
+                $table->foreignId('type_id')->nullable()->constrained('codeable_concepts');
+                $table->foreignId('range_id')->nullable()->constrained('ranges');
+                $table->string('rate_ratio')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dose_rates');
+        Schema::dropIfExists('dosage_instructions');
+        Schema::dropIfExists('medication_request_requests');
+        Schema::dropIfExists('dosages');
+    }
+};

--- a/database/migrations/update/0_1/2026_06_01_000002_create_referral_requests_tables.php
+++ b/database/migrations/update/0_1/2026_06_01_000002_create_referral_requests_tables.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 1. service_request_requests table
+        if (!Schema::hasTable('service_request_requests')) {
+            Schema::create('service_request_requests', static function (Blueprint $table) {
+                $table->id();
+                $table->uuid('uuid')->unique();
+                $table->foreignId('employee_id')->constrained('employees');
+                $table->foreignId('person_id')->constrained('persons');
+                $table->foreignId('division_id')->nullable()->constrained('divisions');
+                $table->string('status');
+                $table->string('request_number')->nullable(); // Requisition code
+                $table->timestamp('started_at')->nullable();
+                $table->timestamp('ended_at')->nullable();
+                $table->string('service_id'); // Service code or concept
+                $table->decimal('quantity', 15, 2)->default(1);
+                $table->string('program_id')->nullable();
+                $table->string('intent');
+                $table->string('category')->nullable();
+                $table->foreignId('based_on_id')->nullable()->constrained('care_plan_activities');
+                $table->foreignId('context_id')->nullable()->constrained('encounters');
+                $table->string('priority')->nullable();
+                $table->text('note')->nullable();
+                $table->text('supporting_info')->nullable(); // JSON list of conditions / diagnostic reports
+                $table->timestamps();
+            });
+        }
+
+        // 2. device_request_requests table
+        if (!Schema::hasTable('device_request_requests')) {
+            Schema::create('device_request_requests', static function (Blueprint $table) {
+                $table->id();
+                $table->uuid('uuid')->unique();
+                $table->foreignId('employee_id')->constrained('employees');
+                $table->foreignId('person_id')->constrained('persons');
+                $table->foreignId('division_id')->nullable()->constrained('divisions');
+                $table->string('status');
+                $table->string('request_number')->nullable();
+                $table->timestamp('started_at')->nullable();
+                $table->timestamp('ended_at')->nullable();
+                $table->string('device_id'); // Device code or reference
+                $table->decimal('quantity', 15, 2)->default(1);
+                $table->string('program_id')->nullable();
+                $table->string('intent');
+                $table->string('category')->nullable();
+                $table->foreignId('based_on_id')->nullable()->constrained('care_plan_activities');
+                $table->foreignId('context_id')->nullable()->constrained('encounters');
+                $table->string('priority')->nullable();
+                $table->text('note')->nullable();
+                $table->text('supporting_info')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('device_request_requests');
+        Schema::dropIfExists('service_request_requests');
+    }
+};

--- a/database/migrations/update/0_1/2026_06_01_000003_add_inform_with_to_medication_requests_table.php
+++ b/database/migrations/update/0_1/2026_06_01_000003_add_inform_with_to_medication_requests_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('medication_request_requests', static function (Blueprint $table) {
+            if (!Schema::hasColumn('medication_request_requests', 'inform_with')) {
+                $table->string('inform_with')->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('medication_request_requests', static function (Blueprint $table) {
+            if (Schema::hasColumn('medication_request_requests', 'inform_with')) {
+                $table->dropColumn('inform_with');
+            }
+        });
+    }
+};

--- a/resources/views/components/signature-modal.blade.php
+++ b/resources/views/components/signature-modal.blade.php
@@ -27,9 +27,22 @@
                 <div class="p-6">
                     <form>
                         <div class="flex flex-col gap-6">
-                            @isset($customFields)
-                                {{ $customFields }}
-                            @endisset
+                            @hasSection('custom-fields')
+                                @yield('custom-fields')
+                            @elseif(method_exists($this, 'getStatusReasonsProperty') && isset($this->actionType) && in_array($this->actionType, ['cancel_prescription', 'cancel_referral']))
+                                <div>
+                                    <label for="statusReason" class="default-label">{{ __('care-plan.status_reason') }} *</label>
+                                    <select class="input-modal" wire:model="statusReason" name="statusReason" id="statusReason">
+                                        <option value="" selected>{{__('forms.select')}}</option>
+                                        @foreach($this->statusReasons as $code => $description)
+                                            <option value="{{ $code }}" wire:key="reason-{{ $code }}">
+                                                {{ $description }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                    @error('statusReason') <p class="text-error">{{ $message }}</p> @enderror
+                                </div>
+                            @endif
 
                             {{-- KEP Provider --}}
                             <div>

--- a/resources/views/livewire/care-plan/care-plan-show.blade.php
+++ b/resources/views/livewire/care-plan/care-plan-show.blade.php
@@ -25,9 +25,11 @@
         showMedicationFormDrawer: @entangle('showMedicationFormDrawer'),
         showMedicalDeviceDrawer: @entangle('showMedicalDeviceDrawer'),
         showMedicalDeviceSearchDrawer: @entangle('showMedicalDeviceSearchDrawer'),
-        showMedicalDeviceFormDrawer: @entangle('showMedicalDeviceFormDrawer')
+        showMedicalDeviceFormDrawer: @entangle('showMedicalDeviceFormDrawer'),
+        showEPrescriptionDrawer: @entangle('showEPrescriptionDrawer'),
+        showReferralDrawer: @entangle('showReferralDrawer')
     }" 
-    @close-drawers.window="showServiceDrawer = false; showServiceSearchDrawer = false; showMedicationDrawer = false; showMedicationSearchDrawer = false; showMedicationFormDrawer = false; showMedicalDeviceDrawer = false; showMedicalDeviceSearchDrawer = false; showMedicalDeviceFormDrawer = false;"
+    @close-drawers.window="showServiceDrawer = false; showServiceSearchDrawer = false; showMedicationDrawer = false; showMedicationSearchDrawer = false; showMedicationFormDrawer = false; showMedicalDeviceDrawer = false; showMedicalDeviceSearchDrawer = false; showMedicalDeviceFormDrawer = false; showEPrescriptionDrawer = false; showReferralDrawer = false;"
     class="form shift-content" wire:key="care-plan-show-container">
 
         {{-- Plan Header --}}
@@ -436,27 +438,157 @@
                                                         Підписати призначення
                                                     </button>
                                                 </div>
-                                            @elseif(in_array(strtoupper($activityStatus), ['ACTIVE', 'SCHEDULED', 'IN-PROGRESS', 'IN_PROGRESS', 'ON-HOLD']))
+                                            @elseif(in_array(strtoupper($activityStatus), ['ACTIVE', 'SCHEDULED', 'IN-PROGRESS', 'IN_PROGRESS', 'ON-HOLD', 'PROCESSED']))
                                                 <div class="py-1">
-                                                    <button type="button" 
-                                                            @click="openDropdown = false" 
-                                                            wire:click="openSignatureModal('cancel_activity', {{ $activity->id }})" 
-                                                            class="text-red-600 dark:text-red-400 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600 w-full"
-                                                    >
-                                                        Скасувати призначення
-                                                    </button>
-                                                    <button type="button" 
-                                                            @click="openDropdown = false" 
-                                                            wire:click="openSignatureModal('complete_activity', {{ $activity->id }})" 
+                                                    @if(str_contains(strtolower($kindValue), 'medication'))
+                                                        <button type="button"
+                                                                @click="openDropdown = false"
+                                                                wire:click="initEPrescriptionForm({{ $activity->id }})"
+                                                                class="text-gray-700 dark:text-gray-200 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600 w-full"
+                                                        >
+                                                            Виписати Е-Рецепт
+                                                        </button>
+                                                    @endif
+                                                    @if(str_contains(strtolower($kindValue), 'service_request') || str_contains(strtolower($kindValue), 'device_request'))
+                                                        <button type="button"
+                                                                @click="openDropdown = false"
+                                                                wire:click="initReferralForm({{ $activity->id }})"
+                                                                class="text-gray-700 dark:text-gray-200 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600 w-full"
+                                                        >
+                                                            Створити Направлення
+                                                        </button>
+                                                    @endif
+                                                    <button type="button"
+                                                            @click="openDropdown = false"
+                                                            wire:click="openSignatureModal('complete_activity', {{ $activity->id }})"
                                                             class="text-blue-600 dark:text-blue-400 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600 w-full"
                                                     >
                                                         Завершити призначення
                                                     </button>
+                                                    <button type="button"
+                                                            @click="openDropdown = false"
+                                                            wire:click="openSignatureModal('cancel_activity', {{ $activity->id }})"
+                                                            class="text-red-600 dark:text-red-400 block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600 w-full"
+                                                    >
+                                                        Скасувати призначення
+                                                    </button>
                                                 </div>
                                             @endif
                                         </div>
+                                        </div>
                                     </td>
                                 </tr>
+                                @php
+                                    $linkedPrescriptions = collect($activePrescriptions)->where('based_on_id', $activity->id);
+                                @endphp
+                                @if($linkedPrescriptions->isNotEmpty())
+                                    <tr class="bg-gray-50/50 dark:bg-gray-700/30">
+                                        <td colspan="5" class="px-8 py-3">
+                                            <div class="pl-4 border-l-2 border-blue-500">
+                                                <h4 class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">Виписані Е-Рецепти:</h4>
+                                                <div class="space-y-2">
+                                                    @foreach($linkedPrescriptions as $prescription)
+                                                        <div class="flex items-center justify-between text-sm bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-100 dark:border-gray-700 shadow-sm">
+                                                            <div class="flex items-center gap-4">
+                                                                <span class="font-bold text-gray-900 dark:text-white">№ {{ $prescription['request_number'] ?? $prescription['uuid'] }}</span>
+                                                                <span class="text-gray-500">Кількість: {{ $prescription['medication_qty'] }}</span>
+                                                                <span class="text-gray-400 text-xs">Діє з {{ \Carbon\Carbon::parse($prescription['started_at'])->format('d.m.Y') }} по {{ \Carbon\Carbon::parse($prescription['ended_at'])->format('d.m.Y') }}</span>
+                                                                <span class="badge {{ strtolower($prescription['status']) === 'active' ? 'badge-green' : (strtolower($prescription['status']) === 'new' ? 'badge-yellow' : 'badge-dark') }}">
+                                                                    {{ $prescription['status'] }}
+                                                                </span>
+                                                            </div>
+                                                            <div class="flex items-center gap-3">
+                                                                @if(strtolower($prescription['status']) === 'new')
+                                                                    <button type="button" class="text-green-500 hover:text-green-700 transition-colors flex items-center gap-1" title="Підписати КЕП" wire:click="$set('ePrescriptionRequestIdToSign', '{{ $prescription['uuid'] }}'); openSignatureModal('sign_eprescription')">
+                                                                        @icon('key', 'w-4 h-4')
+                                                                        <span class="text-xs">Підписати</span>
+                                                                    </button>
+                                                                @endif
+                                                                @if(strtolower($prescription['status']) === 'active')
+                                                                    <button type="button" class="text-blue-500 hover:text-blue-700 transition-colors flex items-center gap-1" title="Друк пам'ятки" 
+                                                                            @click="
+                                                                                $wire.loadPrintoutForm('{{ $prescription['uuid'] }}').then(() => {
+                                                                                    let printWindow = window.open('', '_blank');
+                                                                                    printWindow.document.body.innerHTML = $wire.printableContent;
+                                                                                    printWindow.focus();
+                                                                                    printWindow.print();
+                                                                                });
+                                                                            ">
+                                                                        @icon('printer', 'w-4 h-4')
+                                                                        <span class="text-xs">Пам'ятка</span>
+                                                                    </button>
+                                                                    <button type="button" class="text-yellow-600 hover:text-yellow-800 transition-colors flex items-center gap-1" title="Повторно надіслати SMS" wire:click="resendPrescriptionSms('{{ $prescription['uuid'] }}')">
+                                                                        @icon('refresh', 'w-4 h-4')
+                                                                        <span class="text-xs">SMS</span>
+                                                                    </button>
+                                                                    <button type="button" class="text-red-500 hover:text-red-700 transition-colors flex items-center gap-1" title="Скасувати рецепт" wire:click="cancelPrescription('{{ $prescription['uuid'] }}')">
+                                                                        @icon('trash', 'w-4 h-4')
+                                                                        <span class="text-xs">Скасувати</span>
+                                                                    </button>
+                                                                @endif
+                                                            </div>
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endif
+                                @php
+                                    $linkedReferrals = collect($activeReferrals)->where('based_on_id', $activity->id);
+                                @endphp
+                                @if($linkedReferrals->isNotEmpty())
+                                    <tr class="bg-gray-50/50 dark:bg-gray-700/30">
+                                        <td colspan="5" class="px-8 py-3">
+                                            <div class="pl-4 border-l-2 border-green-500">
+                                                <h4 class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">Виписані Направлення:</h4>
+                                                <div class="space-y-2">
+                                                    @foreach($linkedReferrals as $referral)
+                                                        <div class="flex items-center justify-between text-sm bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-100 dark:border-gray-700 shadow-sm">
+                                                            <div class="flex items-center gap-4">
+                                                                <span class="font-bold text-gray-900 dark:text-white">№ {{ $referral['request_number'] ?? $referral['uuid'] }}</span>
+                                                                <span class="text-gray-500">Кількість: {{ $referral['quantity'] }}</span>
+                                                                <span class="text-gray-400 text-xs">Діє з {{ \Carbon\Carbon::parse($referral['started_at'])->format('d.m.Y') }} по {{ \Carbon\Carbon::parse($referral['ended_at'])->format('d.m.Y') }}</span>
+                                                                <span class="badge {{ strtolower($referral['status']) === 'active' ? 'badge-green' : (strtolower($referral['status']) === 'draft' ? 'badge-yellow' : 'badge-dark') }}">
+                                                                    {{ $referral['status'] }}
+                                                                </span>
+                                                            </div>
+                                                            <div class="flex items-center gap-3">
+                                                                @if(strtolower($referral['status']) === 'draft')
+                                                                    @php
+                                                                        $signAction = isset($referral['service_id']) ? 'sign_servicerequest' : 'sign_devicerequest';
+                                                                    @endphp
+                                                                    <button type="button" class="text-green-500 hover:text-green-700 transition-colors flex items-center gap-1" title="Підписати КЕП" wire:click="$set('referralRequestIdToSign', '{{ $referral['uuid'] }}'); openSignatureModal('{{ $signAction }}')">
+                                                                        @icon('key', 'w-4 h-4')
+                                                                        <span class="text-xs">Підписати</span>
+                                                                    </button>
+                                                                @endif
+                                                                @if(strtolower($referral['status']) === 'active')
+                                                                    <button type="button" class="text-blue-500 hover:text-blue-700 transition-colors flex items-center gap-1 mr-2" title="Друк пам'ятки" 
+                                                                            @click="
+                                                                                $wire.loadReferralPrintoutForm('{{ $referral['uuid'] }}').then(() => {
+                                                                                    let printWindow = window.open('', '_blank');
+                                                                                    printWindow.document.body.innerHTML = $wire.printableContent;
+                                                                                    printWindow.focus();
+                                                                                    printWindow.print();
+                                                                                });
+                                                                            ">
+                                                                        @icon('printer', 'w-4 h-4')
+                                                                        <span class="text-xs">Пам'ятка</span>
+                                                                    </button>
+                                                                    <button type="button" class="text-red-500 hover:text-red-700 transition-colors flex items-center gap-1" title="Скасувати направлення" wire:click="cancelReferral('{{ $referral['uuid'] }}', '{{ isset($referral['service_id']) ? 'service_request' : 'device_request' }}')">
+                                                                        @icon('trash', 'w-4 h-4')
+                                                                        <span class="text-xs">Скасувати</span>
+                                                                    </button>
+                                                                @endif
+                                                            </div>
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endif
                             @empty
                                 <tr>
                                     <td colspan="5" class="px-4 py-12 text-center text-gray-400 italic">
@@ -497,6 +629,8 @@
         @include('livewire.care-plan.parts.modals.medical-devices-drawer')
         @include('livewire.care-plan.parts.modals.medical-device-search-drawer')
         @include('livewire.care-plan.parts.modals.medical-device-form-drawer')
+        @include('livewire.care-plan.parts.modals.eprescription-form-drawer')
+        @include('livewire.care-plan.parts.modals.referral-form-drawer')
     </div>
 
     <livewire:components.x-message :key="time()" />

--- a/resources/views/livewire/care-plan/parts/modals/eprescription-form-drawer.blade.php
+++ b/resources/views/livewire/care-plan/parts/modals/eprescription-form-drawer.blade.php
@@ -1,0 +1,240 @@
+{{-- E-Prescription Form Drawer Overlay --}}
+<div x-show="showEPrescriptionDrawer"
+     x-transition:enter="transition ease-out duration-300"
+     x-transition:enter-start="opacity-0"
+     x-transition:enter-end="opacity-100"
+     x-transition:leave="transition ease-in duration-200"
+     x-transition:leave-start="opacity-100"
+     x-transition:leave-end="opacity-0"
+     x-cloak
+     @click="showEPrescriptionDrawer = false"
+     class="fixed top-0 right-0 h-screen pt-20 bg-gray-900/50"
+     style="z-index: 46; width: calc(80% - 30px);"
+></div>
+
+{{-- E-Prescription Form Drawer --}}
+<div id="eprescription-form-drawer-right"
+     x-show="showEPrescriptionDrawer"
+     x-transition:enter="transition ease-out duration-300"
+     x-transition:enter-start="translate-x-full"
+     x-transition:enter-end="translate-x-0"
+     x-transition:leave="transition ease-in duration-200"
+     x-transition:leave-start="translate-x-0"
+     x-transition:leave-end="translate-x-full"
+     x-cloak
+     class="fixed top-0 right-0 h-screen pt-20 p-4 overflow-y-auto bg-white dark:bg-gray-800 shadow-2xl"
+     style="z-index: 47; width: calc(80% - 60px);"
+     tabindex="-1"
+>
+    <h3 class="modal-header">
+        Виписати Електронний Рецепт (на основі Плану Лікування)
+    </h3>
+
+    @if(!empty($ePrescriptionForm))
+    <form wire:submit.prevent="validateEPrescription">
+        {{-- Section 1: Main Reference Data --}}
+        <fieldset class="fieldset">
+            <legend class="legend">Основні дані</legend>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">План лікування</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed" value="{{ $carePlan->title }}" disabled />
+                </div>
+                <div class="form-group group">
+                    <label class="label">Призначення (Activity)</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed" value="{{ $ePrescriptionSelectedActivity ? ($ePrescriptionSelectedActivity['description'] ?? 'Призначення ЛЗ') : '' }}" disabled />
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">Лікарський засіб (ЛЗ)</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed font-medium text-gray-900 dark:text-white" value="{{ $ePrescriptionSelectedProduct ? ($ePrescriptionSelectedProduct['name'] ?? '') : '' }}" disabled />
+                </div>
+                <div class="form-group group">
+                    <label class="label">Медична програма</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed" value="{{ $ePrescriptionSelectedProgram ? ($ePrescriptionSelectedProgram['name'] ?? '') : 'Загальні призначення' }}" disabled />
+                </div>
+            </div>
+        </fieldset>
+
+        {{-- Section 2: Treatment Duration and Quantities --}}
+        <fieldset class="fieldset">
+            <legend class="legend">Курс лікування та Кількість</legend>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">Дата початку лікування*</label>
+                    <div class="relative">
+                        <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                            @icon('calendar-month', 'w-4 h-4 text-gray-500')
+                        </div>
+                        <input type="text"
+                               class="input peer ps-10"
+                               placeholder="dd.mm.yyyy"
+                               wire:model.live="ePrescriptionForm.started_at"
+                               @if(!$ePrescriptionSkipTreatmentPeriod) disabled @endif
+                        />
+                    </div>
+                </div>
+
+                <div class="form-group group">
+                    <label class="label">Тривалість курсу (дні)*</label>
+                    <input type="number" class="input peer" min="1" wire:model.live="ePrescriptionForm.duration" />
+                </div>
+
+                <div class="form-group group">
+                    <label class="label">Дата закінчення лікування</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed" value="{{ $ePrescriptionForm['ended_at'] ?? '' }}" disabled />
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">Кількість ЛЗ на весь курс*</label>
+                    <div class="flex gap-2">
+                        @if(!empty($ePrescriptionMultiples))
+                            <select class="input-select peer w-full" wire:model="ePrescriptionForm.medication_qty">
+                                <option value="">Оберіть кількість...</option>
+                                @foreach($ePrescriptionMultiples as $qty)
+                                    <option value="{{ $qty }}">{{ $qty }}</option>
+                                @endforeach
+                            </select>
+                        @else
+                            <input type="number" step="any" min="0.01" class="input peer w-full" wire:model="ePrescriptionForm.medication_qty" />
+                        @endif
+                        <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-500 text-sm">
+                            {{ $ePrescriptionForm['medication_unit'] ?? 'од.' }}
+                        </span>
+                    </div>
+                </div>
+
+                @if(!empty($ePrescriptionPackages))
+                    <div class="form-group group col-span-2">
+                        <label class="label">Первинна упаковка (обсяг)*</label>
+                        <select class="input-select peer w-full" wire:model="ePrescriptionForm.container_dosage">
+                            <option value="">Оберіть упаковку...</option>
+                            @foreach($ePrescriptionPackages as $package)
+                                @php
+                                    $value = $package['container_dosage']['value'] ?? null;
+                                    $unit = $package['container_dosage']['numerator']['unit'] ?? ($package['container_dosage']['numerator_unit'] ?? 'од.');
+                                    $code = $package['container_dosage']['code'] ?? '';
+                                @endphp
+                                <option value="{{ $value }}|{{ $unit }}|{{ $code }}">{{ $value }} {{ $unit }} (Код: {{ $code }})</option>
+                            @endforeach
+                        </select>
+                    </div>
+                @endif
+            </div>
+
+            {{-- Quantity Warnings --}}
+            @if($ePrescriptionWarningMessage)
+                <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 border border-red-200 dark:border-red-900" role="alert">
+                    <div class="flex items-center gap-2">
+                        @icon('alert-circle', 'w-5 h-5 text-red-500')
+                        <span class="font-bold">Увага!</span>
+                    </div>
+                    <div class="mt-2">{!! $ePrescriptionWarningMessage !!}</div>
+                </div>
+            @endif
+
+            @if($ePrescriptionShowRemainingQtyWarning)
+                <div class="p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-900" role="alert">
+                    <div class="flex items-center gap-2">
+                        @icon('alert-circle', 'w-5 h-5 text-yellow-500')
+                        <span class="font-bold">Увага! залишкова кількість</span>
+                    </div>
+                    <div class="mt-2">
+                        Для пацієнта в плані лікування залишалось лікарського засобу в кількості {{ $ePrescriptionRemainingQty }} {{ $ePrescriptionForm['medication_unit'] ?? '' }}.
+                    </div>
+                </div>
+            @endif
+        </fieldset>
+
+        {{-- Section 3: Dosage instructions (Signature) --}}
+        <fieldset class="fieldset">
+            <legend class="legend">Спосіб застосування (Сигнатура)</legend>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">Разова доза ЛЗ (на один прийом)*</label>
+                    <div class="flex gap-2">
+                        <input type="number" step="any" min="0.01" class="input peer w-full" wire:model="ePrescriptionForm.max_dose_per_administration" />
+                        <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-500 text-sm">
+                            {{ $ePrescriptionForm['medication_unit'] ?? 'од.' }}
+                        </span>
+                    </div>
+                </div>
+
+                <div class="form-group group">
+                    <label class="label">Максимальна добова доза ЛЗ*</label>
+                    <div class="flex gap-2">
+                        <input type="number" step="any" min="0.01" class="input peer w-full" wire:model="ePrescriptionForm.max_dose_per_period" />
+                        <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-500 text-sm">
+                            {{ $ePrescriptionForm['medication_unit'] ?? 'од.' }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-group group mb-4">
+                <label class="label">Текст сигнатури (спосіб застосування)*</label>
+                <textarea class="block w-full p-4 text-sm text-gray-900 bg-white border border-gray-200 rounded-2xl focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                          rows="3"
+                          placeholder="Приймати по 1 таблетці 2 рази на день після їжі"
+                          wire:model="ePrescriptionForm.signature_text"
+                ></textarea>
+            </div>
+
+            @if($ePrescriptionShowDailyDoseWarning)
+                <div class="p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-900" role="alert">
+                    <div class="flex items-center gap-2">
+                        @icon('alert-circle', 'w-5 h-5 text-yellow-500')
+                        <span class="font-bold">Увага! Перевищено добову дозу</span>
+                    </div>
+                    <div class="mt-2">
+                        Пацієнту перевищено підтримуючу/визначену в плані лікування добову дозу лікарського засобу [{{ $ePrescriptionSelectedProduct['name'] ?? '' }}].
+                        <br/>
+                        Чи впевнені Ви у виписуванні пацієнту такої кількості лікарського засобу на добу?
+                    </div>
+                    <div class="mt-4 flex gap-4">
+                        <button type="button" class="button-primary py-1 px-3 text-xs" wire:click="confirmExceededDailyDose(true)">
+                            Так, впевнений
+                        </button>
+                        <button type="button" class="button-minor py-1 px-3 text-xs" wire:click="confirmExceededDailyDose(false)">
+                            Ні, скоригувати
+                        </button>
+                    </div>
+                </div>
+            @endif
+        </fieldset>
+
+        {{-- Section 4: Authentication --}}
+        <fieldset class="fieldset">
+            <legend class="legend">Автентифікація пацієнта</legend>
+            <div class="form-group group">
+                <label class="label">Метод автентифікації*</label>
+                <select class="input-select peer w-full" wire:model="ePrescriptionForm.inform_with">
+                    <option value="">Оберіть метод...</option>
+                    @foreach($ePrescriptionAuthMethods as $method)
+                        @php
+                            $typeLabel = $method['type'] === 'OTP' ? 'Автентифікація через СМС (OTP)' : ($method['type'] === 'THIRD_PERSON' ? 'Автентифікація через довірену особу' : 'Автентифікація через документи');
+                            $valueLabel = $method['phone_number'] ?? $method['alias'] ?? '';
+                        @endphp
+                        <option value="{{ $method['uuid'] }}|{{ $method['type'] }}|{{ $valueLabel }}">{{ $typeLabel }} {{ $valueLabel ? '('.$valueLabel.')' : '' }}</option>
+                    @endforeach
+                </select>
+            </div>
+        </fieldset>
+
+        <div class="mt-6 flex justify-start gap-3">
+            <button type="button" class="button-minor" @click="showEPrescriptionDrawer = false">
+                {{ __('forms.cancel') }}
+            </button>
+            <button type="submit" class="button-primary" @if($ePrescriptionShowDailyDoseWarning || $ePrescriptionWarningMessage) disabled class="opacity-50 cursor-not-allowed button-primary" @endif>
+                Сформувати Заявку
+            </button>
+        </div>
+    </form>
+    @endif
+</div>

--- a/resources/views/livewire/care-plan/parts/modals/referral-form-drawer.blade.php
+++ b/resources/views/livewire/care-plan/parts/modals/referral-form-drawer.blade.php
@@ -1,0 +1,204 @@
+{{-- Outgoing Referral Form Drawer Overlay --}}
+<div x-show="showReferralDrawer"
+     x-transition:enter="transition ease-out duration-300"
+     x-transition:enter-start="opacity-0"
+     x-transition:enter-end="opacity-100"
+     x-transition:leave="transition ease-in duration-200"
+     x-transition:leave-start="opacity-100"
+     x-transition:leave-end="opacity-0"
+     x-cloak
+     @click="showReferralDrawer = false"
+     class="fixed top-0 right-0 h-screen pt-20 bg-gray-900/50"
+     style="z-index: 46; width: calc(80% - 30px);"
+></div>
+
+{{-- Outgoing Referral Form Drawer --}}
+<div id="referral-form-drawer-right"
+     x-show="showReferralDrawer"
+     x-transition:enter="transition ease-out duration-300"
+     x-transition:enter-start="translate-x-full"
+     x-transition:enter-end="translate-x-0"
+     x-transition:leave="transition ease-in duration-200"
+     x-transition:leave-start="translate-x-0"
+     x-transition:leave-end="translate-x-full"
+     x-cloak
+     class="fixed top-0 right-0 h-screen pt-20 p-4 overflow-y-auto bg-white dark:bg-gray-800 shadow-2xl"
+     style="z-index: 47; width: calc(80% - 60px);"
+     tabindex="-1"
+>
+    <h3 class="modal-header">
+        Виписати Електронне Направлення (на основі Плану Лікування)
+    </h3>
+
+    @if(!empty($referralForm))
+    <form wire:submit.prevent="validateReferral">
+        {{-- Section 1: Main Reference Data --}}
+        <fieldset class="fieldset">
+            <legend class="legend">Основні дані</legend>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">План лікування</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed" value="{{ $carePlan->title }}" disabled />
+                </div>
+                <div class="form-group group">
+                    <label class="label">Призначення (Activity)</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed" value="{{ $referralSelectedActivity ? ($referralSelectedActivity['description'] ?? 'Призначення') : '' }}" disabled />
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">Послуга / Виріб (Код)</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed font-medium text-gray-900 dark:text-white" value="{{ $referralForm['code'] }}" disabled />
+                </div>
+                <div class="form-group group">
+                    <label class="label">Тип направлення</label>
+                    <input type="text" class="input bg-gray-50 dark:bg-gray-700 cursor-not-allowed" value="{{ $referralForm['kind'] === 'service_request' ? 'Направлення на Послугу' : 'Направлення на виріб (Device)' }}" disabled />
+                </div>
+            </div>
+        </fieldset>
+
+        {{-- Section 2: Validity and Quantities --}}
+        <fieldset class="fieldset">
+            <legend class="legend">Термін дії та Кількість</legend>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-4">
+                <div class="form-group group">
+                    <label class="label">Дата початку дії*</label>
+                    <div class="relative">
+                        <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                            @icon('calendar-month', 'w-4 h-4 text-gray-500')
+                        </div>
+                        <input type="text"
+                               class="input peer ps-10"
+                               placeholder="dd.mm.yyyy"
+                               wire:model.live="referralForm.started_at"
+                        />
+                    </div>
+                </div>
+
+                <div class="form-group group">
+                    <label class="label">Дата закінчення дії*</label>
+                    <div class="relative">
+                        <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                            @icon('calendar-month', 'w-4 h-4 text-gray-500')
+                        </div>
+                        <input type="text"
+                               class="input peer ps-10"
+                               placeholder="dd.mm.yyyy"
+                               wire:model.live="referralForm.ended_at"
+                        />
+                    </div>
+                </div>
+
+                <div class="form-group group">
+                    <label class="label">Кількість*</label>
+                    <div class="flex gap-2">
+                        <input type="number" step="any" min="0.01" class="input peer w-full" wire:model.live="referralForm.quantity" />
+                        <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 text-gray-500 text-sm">
+                            од.
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            @if($referralForm['kind'] === 'service_request')
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-4">
+                    <div class="form-group group">
+                        <label class="label">Категорія направлення*</label>
+                        <select class="input-select peer w-full" wire:model="referralForm.category">
+                            <option value="procedure">Процедура (Procedure)</option>
+                            <option value="diagnostic">Діагностичне дослідження (Diagnostic)</option>
+                            <option value="education">Навчання пацієнта (Education)</option>
+                            <option value="counseling">Консультування (Counseling)</option>
+                            <option value="hospital_referral">Направлення в стаціонар (Hospital Referral)</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group group">
+                        <label class="label">Пріоритет*</label>
+                        <select class="input-select peer w-full" wire:model="referralForm.priority">
+                            <option value="routine">Планове (Routine)</option>
+                            <option value="urgent">Ургентне (Urgent)</option>
+                            <option value="asap">Якнайшвидше (ASAP)</option>
+                            <option value="stat">Негайно (STAT)</option>
+                        </select>
+                    </div>
+                </div>
+            @else
+                <div class="grid grid-cols-1 gap-6 mb-4">
+                    <div class="form-group group">
+                        <label class="label">Пріоритет*</label>
+                        <select class="input-select peer w-full" wire:model="referralForm.priority">
+                            <option value="routine">Планове (Routine)</option>
+                            <option value="urgent">Ургентне (Urgent)</option>
+                            <option value="asap">Якнайшвидше (ASAP)</option>
+                            <option value="stat">Негайно (STAT)</option>
+                        </select>
+                    </div>
+                </div>
+            @endif
+
+            {{-- Warnings --}}
+            @if($referralWarningMessage)
+                <div class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 border border-red-200 dark:border-red-900" role="alert">
+                    <div class="flex items-center gap-2">
+                        @icon('alert-circle', 'w-5 h-5 text-red-500')
+                        <span class="font-bold">Увага!</span>
+                    </div>
+                    <div class="mt-2">{!! $referralWarningMessage !!}</div>
+                </div>
+            @endif
+
+            @if($referralShowRemainingQtyWarning)
+                <div class="p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-900" role="alert">
+                    <div class="flex items-center gap-2">
+                        @icon('alert-circle', 'w-5 h-5 text-yellow-500')
+                        <span class="font-bold">Увага! залишкова кількість</span>
+                    </div>
+                    <div class="mt-2">
+                        Для пацієнта в плані лікування залишалось послуг/виробів в кількості {{ $referralRemainingQty }} од.
+                    </div>
+                </div>
+            @endif
+        </fieldset>
+
+        {{-- Section 3: Extra Info --}}
+        <fieldset class="fieldset">
+            <legend class="legend">Додаткова інформація</legend>
+
+            <div class="form-group group mb-4">
+                <label class="label">Нотатка / Обґрунтування лікаря</label>
+                <textarea class="block w-full p-4 text-sm text-gray-900 bg-white border border-gray-200 rounded-2xl focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                          rows="3"
+                          placeholder="Вкажіть додаткову інформацію до направлення"
+                          wire:model="referralForm.note"
+                ></textarea>
+            </div>
+
+            @if(!empty($referralForm['supporting_info']))
+                <div class="form-group group mb-4">
+                    <label class="label">Клінічне обґрунтування (з призначення)</label>
+                    <div class="space-y-1 bg-gray-50 dark:bg-gray-700/50 p-3 rounded-xl border border-gray-100 dark:border-gray-700">
+                        @foreach($referralForm['supporting_info'] as $info)
+                            <div class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                                <span class="badge badge-minor uppercase">{{ $info['type'] }}</span>
+                                <span class="font-mono text-gray-800 dark:text-gray-200">{{ $info['uuid'] }}</span>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+        </fieldset>
+
+        <div class="mt-6 flex justify-start gap-3">
+            <button type="button" class="button-minor" @click="showReferralDrawer = false">
+                {{ __('forms.cancel') }}
+            </button>
+            <button type="submit" class="button-primary" @if($referralWarningMessage) disabled class="opacity-50 cursor-not-allowed button-primary" @endif>
+                Сформувати Заявку на Направлення
+            </button>
+        </div>
+    </form>
+    @endif
+</div>

--- a/tests/Feature/MedicationRequest/MedicationRequestLifecycleTest.php
+++ b/tests/Feature/MedicationRequest/MedicationRequestLifecycleTest.php
@@ -1,0 +1,401 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\MedicationRequest;
+
+use App\Classes\eHealth\Api\Patient\MedicationRequest as MedicationRequestApi;
+use App\Classes\eHealth\EHealthResponse;
+use App\Models\CarePlanActivity;
+use App\Models\Person\Person;
+use App\Models\Employee\Employee;
+use App\Models\MedicalEvents\Sql\Encounter;
+use App\Repositories\MedicalEvents\Repository;
+use App\Services\MedicalEvents\Mappers\MedicationRequestMapper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+use Livewire\Livewire;
+use App\Livewire\CarePlan\CarePlanShow;
+
+class MedicationRequestLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Person $person;
+    protected Encounter $encounter;
+    protected Employee $employee;
+    protected \App\Models\User $user;
+    protected CarePlanActivity $carePlanActivity;
+
+    protected function migrateDatabases()
+    {
+        $this->artisan('migrate:fresh', [
+            '--path' => [
+                database_path('migrations'),
+                database_path('migrations/install'),
+                database_path('migrations/update/0_1'),
+            ],
+            '--realpath' => true,
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 1. Create Patient
+        $this->person = Person::create([
+            'uuid' => (string) Str::uuid(),
+            'first_name' => 'Олексій',
+            'last_name' => 'Коваль',
+            'birth_date' => '1985-05-15',
+            'gender' => 'MALE',
+            'patient_signed' => true,
+            'process_disclosure_data_consent' => true,
+        ]);
+
+        // 2. Create Encounter & helpers
+        $identifierId = \App\Models\MedicalEvents\Sql\Identifier::create(['value' => (string) Str::uuid()])->id;
+        $codingId = \App\Models\MedicalEvents\Sql\Coding::create(['code' => 'AMB', 'system' => 'eHealth/encounter_classes'])->id;
+        $ccId = \App\Models\MedicalEvents\Sql\CodeableConcept::create()->id;
+
+        $this->encounter = Encounter::create([
+            'uuid' => (string) Str::uuid(),
+            'person_id' => $this->person->id,
+            'status' => 'finished',
+            'episode_id' => $identifierId,
+            'class_id' => $codingId,
+            'type_id' => $ccId,
+            'ehealth_inserted_at' => now(),
+        ]);
+
+        // 3. Create Legal Entity
+        $typeId = \Illuminate\Support\Facades\DB::table('legal_entity_types')->where('name', 'PRIMARY_CARE')->value('id') 
+            ?? \Illuminate\Support\Facades\DB::table('legal_entity_types')->insertGetId(['name' => 'PRIMARY_CARE']);
+
+        $legalEntity = \App\Models\LegalEntity::create([
+            'uuid' => (string) Str::uuid(),
+            'status' => 'ACTIVE',
+            'sync_status' => 'COMPLETED',
+            'legal_entity_type_id' => $typeId,
+            'is_active' => true,
+        ]);
+        $this->instance('legalEntity', $legalEntity);
+
+        // 4. Create Employee
+        $party = \App\Models\Relations\Party::create([
+            'uuid' => (string) Str::uuid(),
+            'first_name' => 'Іван',
+            'last_name' => 'Петренко',
+            'tax_id' => '9876543210',
+            'birth_date' => '1980-08-08',
+            'gender' => 'MALE',
+        ]);
+
+        $this->user = \App\Models\User::create([
+            'uuid' => (string) Str::uuid(),
+            'email' => 'ivan' . Str::random(5) . '@example.com',
+            'password' => \Illuminate\Support\Facades\Hash::make('password'),
+            'party_id' => $party->id,
+        ]);
+
+        $this->employee = Employee::create([
+            'uuid' => (string) Str::uuid(),
+            'full_name' => 'Д-р Іван Петренко',
+            'employee_type' => 'DOCTOR',
+            'status' => 'APPROVED',
+            'legal_entity_id' => $legalEntity->id,
+            'is_active' => true,
+            'position' => 'Doctor',
+            'start_date' => now()->format('Y-m-d'),
+            'user_id' => $this->user->id,
+            'party_id' => $party->id,
+        ]);
+
+        $this->user->employees()->attach($this->employee->id);
+
+        if (config('permission.teams')) {
+            setPermissionsTeamId($legalEntity->id);
+        }
+
+        // 5. Create Care Plan & Medication Care Plan Activity
+        $carePlan = \App\Models\CarePlan::create([
+            'uuid' => (string) Str::uuid(),
+            'person_id' => $this->person->id,
+            'author_id' => $this->employee->id,
+            'legal_entity_id' => $this->employee->legal_entity_id,
+            'period_start' => now()->format('Y-m-d'),
+            'title' => 'Affordable Medicines Plan',
+            'status' => 'active',
+        ]);
+
+        $this->carePlanActivity = CarePlanActivity::create([
+            'uuid' => (string) Str::uuid(),
+            'care_plan_id' => $carePlan->id,
+            'author_id' => $this->employee->id,
+            'status' => 'scheduled',
+            'kind' => 'medication_request',
+            'product_reference' => 'INN-101',
+            'quantity' => 60.0,
+            'program' => 'program-affordable-medicines',
+        ]);
+    }
+
+    public function test_can_persist_medication_request_request_locally(): void
+    {
+        $repo = Repository::medicationRequest();
+
+        $uuid = (string) Str::uuid();
+        $payload = [
+            'uuid' => $uuid,
+            'employee_id' => $this->employee->id,
+            'status' => 'draft',
+            'medication_id' => 'INN-101',
+            'medication_qty' => 60.0,
+            'medication_program_id' => 'program-affordable-medicines',
+            'intent' => 'order',
+            'based_on_id' => $this->carePlanActivity->id,
+            'context_id' => $this->encounter->id,
+            'dosage_instructions' => [
+                [
+                    'sequence' => 1,
+                    'text' => '1 tablet 2 times daily',
+                    'patient_instruction' => 'Take with water',
+                    'route' => 'oral',
+                    'as_needed_boolean' => false,
+                    'dose_and_rate' => [
+                        [
+                            'dose_quantity_value' => 1.0,
+                            'dose_quantity_unit' => 'tab'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $id = $repo->store($payload, $this->person->id);
+        $this->assertGreaterThan(0, $id);
+
+        $this->assertDatabaseHas('medication_request_requests', [
+            'id' => $id,
+            'uuid' => $uuid,
+            'medication_id' => 'INN-101',
+            'person_id' => $this->person->id,
+            'based_on_id' => $this->carePlanActivity->id
+        ]);
+
+        $this->assertDatabaseHas('dosage_instructions', [
+            'medication_request_request_id' => $id,
+            'sequence' => 1,
+            'route' => 'oral',
+            'patient_instruction' => 'Take with water'
+        ]);
+    }
+
+    public function test_can_map_to_fhir_payload(): void
+    {
+        $mapper = new MedicationRequestMapper();
+
+        $payload = [
+            'uuid' => (string) Str::uuid(),
+            'status' => 'draft',
+            'intent' => 'order',
+            'medication_id' => 'INN-101',
+            'medication_qty' => 30.0,
+            'medication_program_id' => 'program-affordable-medicines',
+            'based_on_uuid' => $this->carePlanActivity->uuid,
+            'note' => 'Take in the morning',
+            'dosage_instructions' => [
+                [
+                    'sequence' => 1,
+                    'text' => '1 tablet daily',
+                    'route' => 'oral',
+                    'as_needed_boolean' => false,
+                    'dose_and_rate' => [
+                        [
+                            'dose_quantity_value' => 1.0
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $uuids = [
+            'person_uuid' => $this->person->uuid,
+            'encounter_uuid' => $this->encounter->uuid,
+            'employee_uuid' => $this->employee->uuid,
+            'legal_entity_uuid' => (string) Str::uuid()
+        ];
+
+        $fhir = $mapper->toFhir($payload, $uuids);
+
+        $this->assertEquals($payload['uuid'], $fhir['id']);
+        $this->assertEquals('draft', $fhir['status']);
+        $this->assertEquals('INN-101', $fhir['medicationCodeableConcept']['coding'][0]['code']);
+        $this->assertEquals('program-affordable-medicines', $fhir['program']['identifier']['value']);
+        $this->assertEquals($this->carePlanActivity->uuid, $fhir['basedOn'][0]['identifier']['value']);
+        $this->assertEquals('Take in the morning', $fhir['note'][0]['text']);
+        $this->assertEquals(1.0, $fhir['dosageInstruction'][0]['doseAndRate'][0]['doseQuantity']['value']);
+    }
+
+    public function test_mock_api_create_and_sign_lifecycle(): void
+    {
+        $mockApi = Mockery::mock(MedicationRequestApi::class);
+        $this->instance(MedicationRequestApi::class, $mockApi);
+
+        $requestId = (string) Str::uuid();
+        $finalPrescriptionId = (string) Str::uuid();
+
+        // 1. Mock Create Request
+        $createResponse = Mockery::mock(EHealthResponse::class);
+        $createResponse->shouldReceive('getData')->andReturn([
+            'id' => $requestId,
+            'status' => 'NEW',
+            'request_number' => 'MR-1234567'
+        ]);
+        $createResponse->shouldReceive('getStatusCode')->andReturn(201);
+        $mockApi->shouldReceive('createRequest')->once()->andReturn($createResponse);
+
+        // 2. Mock Sign Request
+        $signResponse = Mockery::mock(EHealthResponse::class);
+        $signResponse->shouldReceive('getData')->andReturn([
+            'id' => $finalPrescriptionId,
+            'status' => 'active',
+            'request_number' => 'MR-1234567'
+        ]);
+        $signResponse->shouldReceive('getStatusCode')->andReturn(200);
+        $mockApi->shouldReceive('signRequest')->once()->andReturn($signResponse);
+
+        // Call the mocked API and assert
+        $resCreate = app(MedicationRequestApi::class)->createRequest($this->person->uuid, []);
+        $this->assertEquals(201, $resCreate->getStatusCode());
+        $this->assertEquals('NEW', $resCreate->getData()['status']);
+
+        $resSign = app(MedicationRequestApi::class)->signRequest($this->person->uuid, $requestId, []);
+        $this->assertEquals(200, $resSign->getStatusCode());
+        $this->assertEquals('active', $resSign->getData()['status']);
+    }
+
+    public function test_livewire_component_actions(): void
+    {
+        // 1. Mock Drug and Program API endpoints
+        $mockDrugApi = Mockery::mock(\App\Classes\eHealth\Api\Drug::class);
+        $drugResponse = Mockery::mock(\App\Classes\eHealth\EHealthResponse::class);
+        $drugResponse->shouldReceive('getData')->andReturn([
+            [
+                'id' => 'INN-101',
+                'name' => 'Test Drug',
+                'innm_dosage_form' => 'ml',
+                'packages' => [
+                    [
+                        'package_min_qty' => 10,
+                        'max_request_dosage' => 100
+                    ]
+                ]
+            ]
+        ]);
+        $drugResponse->shouldReceive('getStatusCode')->andReturn(200);
+        $mockDrugApi->shouldReceive('getMany')->andReturn($drugResponse);
+        $this->instance(\App\Classes\eHealth\Api\Drug::class, $mockDrugApi);
+
+        $mockProgramApi = Mockery::mock(\App\Classes\eHealth\Api\MedicalProgram::class);
+        $programResponse = Mockery::mock(\App\Classes\eHealth\EHealthResponse::class);
+        $programResponse->shouldReceive('getData')->andReturn([
+            [
+                'id' => 'program-1',
+                'name' => 'Affordable Medicines',
+                'settings' => [
+                    'skip_treatment_period' => true,
+                    'request_max_period_day' => 90
+                ]
+            ]
+        ]);
+        $programResponse->shouldReceive('getStatusCode')->andReturn(200);
+        $mockProgramApi->shouldReceive('getMany')->andReturn($programResponse);
+        $this->instance(\App\Classes\eHealth\Api\MedicalProgram::class, $mockProgramApi);
+
+        $mockPersonApi = Mockery::mock(\App\Classes\eHealth\Api\Person::class);
+        $personResponse = Mockery::mock(\App\Classes\eHealth\EHealthResponse::class);
+        $personResponse->shouldReceive('getData')->andReturn([
+            [
+                'uuid' => 'auth-1',
+                'type' => 'OTP',
+                'phone_number' => '+380991112233'
+            ]
+        ]);
+        $personResponse->shouldReceive('getStatusCode')->andReturn(200);
+        $mockPersonApi->shouldReceive('getAuthMethods')->andReturn($personResponse);
+        $this->instance(\App\Classes\eHealth\Api\Person::class, $mockPersonApi);
+
+        // 2. Fetch the CarePlan
+        $carePlan = $this->carePlanActivity->carePlan;
+
+        // 3. Test Livewire rendering & initEPrescriptionForm
+        Livewire::test(CarePlanShow::class, ['carePlan' => $carePlan])
+            ->assertSet('showEPrescriptionDrawer', false)
+            ->call('initEPrescriptionForm', $this->carePlanActivity->id)
+            ->assertSet('showEPrescriptionDrawer', true)
+            ->assertSet('ePrescriptionForm.medication_id', 'INN-101')
+            ->assertSet('ePrescriptionForm.medication_qty', 10)
+            ->set('ePrescriptionForm.duration', 15)
+            ->call('calculateTreatmentDates')
+            ->assertSet('ePrescriptionForm.duration', 15);
+    }
+
+    public function test_livewire_prescription_cancellation(): void
+    {
+        $carePlan = $this->carePlanActivity->carePlan;
+        $this->actingAs($this->user);
+
+        // Create a mock MedicationRequestRequest in DB
+        $uuid = (string) Str::uuid();
+        $medicationRequest = \App\Models\MedicalEvents\Sql\Medications\MedicationRequestRequest::create([
+            'uuid' => $uuid,
+            'employee_id' => $this->employee->id,
+            'person_id' => $this->person->id,
+            'status' => 'active',
+            'medication_id' => 'INN-101',
+            'medication_qty' => 30.0,
+            'intent' => 'order',
+            'based_on_id' => $this->carePlanActivity->id,
+            'context_id' => $this->encounter->id,
+            'request_number' => 'MR-777777',
+            'inform_with' => 'otp-method-uuid|OTP|+380991112233'
+        ]);
+
+        // Mock eHealth cancel API
+        $mockApi = Mockery::mock(MedicationRequestApi::class);
+        $cancelResponse = Mockery::mock(EHealthResponse::class);
+        $cancelResponse->shouldReceive('successful')->andReturn(true);
+        $cancelResponse->shouldReceive('getData')->andReturn(['status' => 'cancelled']);
+        $mockApi->shouldReceive('cancel')->once()->andReturn($cancelResponse);
+        $this->instance(MedicationRequestApi::class, $mockApi);
+
+        // Mock SignatureService
+        $mockSignatureService = Mockery::mock(\App\Services\SignatureService::class);
+        $this->instance(\App\Services\SignatureService::class, $mockSignatureService);
+        $mockSignatureService->shouldReceive('signData')->andReturn('mock-base64-signature');
+        $mockSignatureService->shouldReceive('getCertificateAuthorities')->andReturn([]);
+
+        // Livewire test
+        Livewire::test(CarePlanShow::class, ['carePlan' => $carePlan])
+            ->call('cancelPrescription', $uuid)
+            ->assertSet('showSignatureModal', true)
+            ->assertSet('ePrescriptionRequestIdToSign', $uuid)
+            ->assertSet('actionType', 'cancel_prescription')
+            ->set('statusReason', 'entered-in-error')
+            ->set('form.password', '12345678')
+            ->set('form.knedp', 'acsk_test')
+            ->set('form.keyContainerUpload', \Illuminate\Http\UploadedFile::fake()->create('key.dat', 10))
+            ->call('signCancelPrescription')
+            ->assertSet('showSignatureModal', false);
+
+        // Assert database updated
+        $this->assertDatabaseHas('medication_request_requests', [
+            'uuid' => $uuid,
+            'status' => 'cancelled'
+        ]);
+    }
+}

--- a/tests/Feature/Referral/ReferralLifecycleTest.php
+++ b/tests/Feature/Referral/ReferralLifecycleTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Referral;
+
+use App\Classes\eHealth\Api\Patient\ServiceRequest as ServiceRequestApi;
+use App\Classes\eHealth\Api\Patient\DeviceRequest as DeviceRequestApi;
+use App\Classes\eHealth\EHealthResponse;
+use App\Models\CarePlanActivity;
+use App\Models\Person\Person;
+use App\Models\Employee\Employee;
+use App\Models\MedicalEvents\Sql\Encounter;
+use App\Repositories\MedicalEvents\Repository;
+use App\Services\MedicalEvents\Mappers\ServiceRequestMapper;
+use App\Services\MedicalEvents\Mappers\DeviceRequestMapper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+use Livewire\Livewire;
+use App\Livewire\CarePlan\CarePlanShow;
+
+class ReferralLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Person $person;
+    protected Encounter $encounter;
+    protected Employee $employee;
+    protected \App\Models\User $user;
+    protected CarePlanActivity $serviceActivity;
+    protected CarePlanActivity $deviceActivity;
+
+    protected function migrateDatabases()
+    {
+        $this->artisan('migrate:fresh', [
+            '--path' => [
+                database_path('migrations'),
+                database_path('migrations/install'),
+                database_path('migrations/update/0_1'),
+            ],
+            '--realpath' => true,
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 1. Create Patient
+        $this->person = Person::create([
+            'uuid' => (string) Str::uuid(),
+            'first_name' => 'Олексій',
+            'last_name' => 'Коваль',
+            'birth_date' => '1985-05-15',
+            'gender' => 'MALE',
+            'patient_signed' => true,
+            'process_disclosure_data_consent' => true,
+        ]);
+
+        // 2. Create Encounter & helpers
+        $identifierId = \App\Models\MedicalEvents\Sql\Identifier::create(['value' => (string) Str::uuid()])->id;
+        $codingId = \App\Models\MedicalEvents\Sql\Coding::create(['code' => 'AMB', 'system' => 'eHealth/encounter_classes'])->id;
+        $ccId = \App\Models\MedicalEvents\Sql\CodeableConcept::create()->id;
+
+        $this->encounter = Encounter::create([
+            'uuid' => (string) Str::uuid(),
+            'person_id' => $this->person->id,
+            'status' => 'finished',
+            'episode_id' => $identifierId,
+            'class_id' => $codingId,
+            'type_id' => $ccId,
+            'ehealth_inserted_at' => now(),
+        ]);
+
+        // 3. Create Legal Entity
+        $typeId = \Illuminate\Support\Facades\DB::table('legal_entity_types')->where('name', 'PRIMARY_CARE')->value('id') 
+            ?? \Illuminate\Support\Facades\DB::table('legal_entity_types')->insertGetId(['name' => 'PRIMARY_CARE']);
+
+        $legalEntity = \App\Models\LegalEntity::create([
+            'uuid' => (string) Str::uuid(),
+            'status' => 'ACTIVE',
+            'sync_status' => 'COMPLETED',
+            'legal_entity_type_id' => $typeId,
+            'is_active' => true,
+        ]);
+        $this->instance('legalEntity', $legalEntity);
+
+        // 4. Create Employee
+        $party = \App\Models\Relations\Party::create([
+            'uuid' => (string) Str::uuid(),
+            'first_name' => 'Іван',
+            'last_name' => 'Петренко',
+            'tax_id' => '9876543210',
+            'birth_date' => '1980-08-08',
+            'gender' => 'MALE',
+        ]);
+
+        $this->user = \App\Models\User::create([
+            'uuid' => (string) Str::uuid(),
+            'email' => 'ivan' . Str::random(5) . '@example.com',
+            'password' => \Illuminate\Support\Facades\Hash::make('password'),
+            'party_id' => $party->id,
+        ]);
+
+        $this->employee = Employee::create([
+            'uuid' => (string) Str::uuid(),
+            'full_name' => 'Д-р Іван Петренко',
+            'employee_type' => 'DOCTOR',
+            'status' => 'APPROVED',
+            'legal_entity_id' => $legalEntity->id,
+            'is_active' => true,
+            'position' => 'Doctor',
+            'start_date' => now()->format('Y-m-d'),
+            'user_id' => $this->user->id,
+            'party_id' => $party->id,
+        ]);
+
+        $this->user->employees()->attach($this->employee->id);
+
+        if (config('permission.teams')) {
+            setPermissionsTeamId($legalEntity->id);
+        }
+
+        // 5. Create Care Plan & Referral Care Plan Activities
+        $carePlan = \App\Models\CarePlan::create([
+            'uuid' => (string) Str::uuid(),
+            'person_id' => $this->person->id,
+            'author_id' => $this->employee->id,
+            'legal_entity_id' => $this->employee->legal_entity_id,
+            'period_start' => now()->format('Y-m-d'),
+            'title' => 'Referral Care Plan',
+            'status' => 'active',
+        ]);
+
+        $this->serviceActivity = CarePlanActivity::create([
+            'uuid' => (string) Str::uuid(),
+            'care_plan_id' => $carePlan->id,
+            'author_id' => $this->employee->id,
+            'status' => 'scheduled',
+            'kind' => 'service_request',
+            'product_reference' => '59300-00', // Diagnostic service code
+            'quantity' => 5.0,
+        ]);
+
+        $this->deviceActivity = CarePlanActivity::create([
+            'uuid' => (string) Str::uuid(),
+            'care_plan_id' => $carePlan->id,
+            'author_id' => $this->employee->id,
+            'status' => 'scheduled',
+            'kind' => 'device_request',
+            'product_reference' => 'D-707', // Assistive device code
+            'quantity' => 1.0,
+        ]);
+    }
+
+    public function test_can_persist_referral_requests_locally(): void
+    {
+        $serviceRepo = Repository::serviceRequest();
+        $deviceRepo = Repository::deviceRequest();
+
+        $serviceUuid = (string) Str::uuid();
+        $deviceUuid = (string) Str::uuid();
+
+        $serviceData = [
+            'uuid' => $serviceUuid,
+            'employee_id' => $this->employee->id,
+            'status' => 'draft',
+            'service_id' => '59300-00',
+            'quantity' => 2.0,
+            'intent' => 'order',
+            'category' => 'procedure',
+            'based_on_id' => $this->serviceActivity->id,
+            'context_id' => $this->encounter->id,
+            'priority' => 'routine',
+            'note' => 'Please perform procedure ASAP',
+        ];
+
+        $deviceData = [
+            'uuid' => $deviceUuid,
+            'employee_id' => $this->employee->id,
+            'status' => 'draft',
+            'device_id' => 'D-707',
+            'quantity' => 1.0,
+            'intent' => 'order',
+            'based_on_id' => $this->deviceActivity->id,
+            'context_id' => $this->encounter->id,
+            'priority' => 'urgent',
+            'note' => 'Patient needs wheelchair',
+        ];
+
+        $serviceId = $serviceRepo->store($serviceData, $this->person->id);
+        $deviceId = $deviceRepo->store($deviceData, $this->person->id);
+
+        $this->assertGreaterThan(0, $serviceId);
+        $this->assertGreaterThan(0, $deviceId);
+
+        $this->assertDatabaseHas('service_request_requests', [
+            'id' => $serviceId,
+            'uuid' => $serviceUuid,
+            'service_id' => '59300-00',
+            'person_id' => $this->person->id,
+            'based_on_id' => $this->serviceActivity->id,
+        ]);
+
+        $this->assertDatabaseHas('device_request_requests', [
+            'id' => $deviceId,
+            'uuid' => $deviceUuid,
+            'device_id' => 'D-707',
+            'person_id' => $this->person->id,
+            'based_on_id' => $this->deviceActivity->id,
+        ]);
+    }
+
+    public function test_can_map_to_fhir_payloads(): void
+    {
+        $serviceMapper = new ServiceRequestMapper();
+        $deviceMapper = new DeviceRequestMapper();
+
+        $serviceData = [
+            'uuid' => (string) Str::uuid(),
+            'status' => 'draft',
+            'intent' => 'order',
+            'service_id' => '59300-00',
+            'quantity' => 2.0,
+            'category' => 'procedure',
+            'based_on_uuid' => $this->serviceActivity->uuid,
+            'priority' => 'routine',
+            'note' => 'Service note',
+            'started_at' => '2026-06-01',
+            'ended_at' => '2026-09-01',
+        ];
+
+        $deviceData = [
+            'uuid' => (string) Str::uuid(),
+            'status' => 'draft',
+            'intent' => 'order',
+            'device_id' => 'D-707',
+            'quantity' => 1.0,
+            'based_on_uuid' => $this->deviceActivity->uuid,
+            'priority' => 'urgent',
+            'note' => 'Device note',
+            'started_at' => '2026-06-01',
+            'ended_at' => '2026-09-01',
+        ];
+
+        $uuids = [
+            'person_uuid' => $this->person->uuid,
+            'encounter_uuid' => $this->encounter->uuid,
+            'employee_uuid' => $this->employee->uuid,
+            'legal_entity_uuid' => (string) Str::uuid()
+        ];
+
+        $serviceFhir = $serviceMapper->toFhir($serviceData, $uuids);
+        $deviceFhir = $deviceMapper->toFhir($deviceData, $uuids);
+
+        // ServiceRequest assertions
+        $this->assertEquals($serviceData['uuid'], $serviceFhir['id']);
+        $this->assertEquals('draft', $serviceFhir['status']);
+        $this->assertEquals('59300-00', $serviceFhir['code']['coding'][0]['code']);
+        $this->assertEquals($this->serviceActivity->uuid, $serviceFhir['basedOn'][0]['identifier']['value']);
+        $this->assertEquals(2, $serviceFhir['quantityInteger']);
+
+        // DeviceRequest assertions
+        $this->assertEquals($deviceData['uuid'], $deviceFhir['id']);
+        $this->assertEquals('draft', $deviceFhir['status']);
+        $this->assertEquals('D-707', $deviceFhir['codeCodeableConcept']['coding'][0]['code']);
+        $this->assertEquals($this->deviceActivity->uuid, $deviceFhir['basedOn'][0]['identifier']['value']);
+        $this->assertEquals(1, $deviceFhir['quantityInteger']);
+    }
+
+    public function test_mock_api_create_and_sign_lifecycle(): void
+    {
+        $mockServiceApi = Mockery::mock(ServiceRequestApi::class);
+        $this->instance(ServiceRequestApi::class, $mockServiceApi);
+
+        $mockDeviceApi = Mockery::mock(DeviceRequestApi::class);
+        $this->instance(DeviceRequestApi::class, $mockDeviceApi);
+
+        $serviceRequestId = (string) Str::uuid();
+        $deviceRequestId = (string) Str::uuid();
+
+        // Mock ServiceRequest API
+        $serviceCreateResponse = Mockery::mock(EHealthResponse::class);
+        $serviceCreateResponse->shouldReceive('getData')->andReturn([
+            'id' => $serviceRequestId,
+            'status' => 'NEW',
+            'request_number' => 'SR-11112222'
+        ]);
+        $serviceCreateResponse->shouldReceive('getStatusCode')->andReturn(201);
+        $mockServiceApi->shouldReceive('createRequest')->once()->andReturn($serviceCreateResponse);
+
+        $serviceSignResponse = Mockery::mock(EHealthResponse::class);
+        $serviceSignResponse->shouldReceive('getData')->andReturn([
+            'id' => (string) Str::uuid(),
+            'status' => 'active',
+            'request_number' => 'SR-11112222'
+        ]);
+        $serviceSignResponse->shouldReceive('getStatusCode')->andReturn(200);
+        $mockServiceApi->shouldReceive('signRequest')->once()->andReturn($serviceSignResponse);
+
+        // Assert ServiceRequest API
+        $resServiceCreate = app(ServiceRequestApi::class)->createRequest($this->person->uuid, []);
+        $this->assertEquals(201, $resServiceCreate->getStatusCode());
+        $this->assertEquals('NEW', $resServiceCreate->getData()['status']);
+
+        $resServiceSign = app(ServiceRequestApi::class)->signRequest($this->person->uuid, $serviceRequestId, []);
+        $this->assertEquals(200, $resServiceSign->getStatusCode());
+        $this->assertEquals('active', $resServiceSign->getData()['status']);
+    }
+
+    public function test_livewire_component_actions(): void
+    {
+        // Fetch the CarePlan
+        $carePlan = $this->serviceActivity->carePlan;
+
+        // Authenticate the employee user
+        $this->actingAs($this->user);
+
+        // Test Livewire triggers
+        Livewire::test(CarePlanShow::class, ['carePlan' => $carePlan])
+            ->assertSet('showReferralDrawer', false)
+            ->call('initReferralForm', $this->serviceActivity->id)
+            ->assertSet('showReferralDrawer', true)
+            ->assertSet('referralForm.code', $this->serviceActivity->product_reference)
+            ->assertSet('referralForm.quantity', 1.0)
+            ->set('referralForm.quantity', 3.0)
+            ->set('referralForm.category', 'procedure')
+            ->call('validateReferral')
+            ->assertSet('showReferralDrawer', false)
+            ->assertSet('showSignatureModal', true);
+    }
+
+    public function test_livewire_referral_cancellation(): void
+    {
+        $carePlan = $this->serviceActivity->carePlan;
+        $this->actingAs($this->user);
+
+        // Create a mock ServiceRequestRequest in the DB
+        $uuid = (string) Str::uuid();
+        $serviceRequest = \App\Models\MedicalEvents\Sql\ServiceRequestRequest::create([
+            'uuid' => $uuid,
+            'employee_id' => $this->employee->id,
+            'person_id' => $this->person->id,
+            'status' => 'active',
+            'service_id' => '59300-00',
+            'quantity' => 1.0,
+            'intent' => 'order',
+            'based_on_id' => $this->serviceActivity->id,
+            'context_id' => $this->encounter->id,
+            'priority' => 'routine',
+            'request_number' => 'SR-999999'
+        ]);
+
+        // Mock eHealth ServiceRequest cancel API
+        $mockServiceApi = Mockery::mock(ServiceRequestApi::class);
+        $cancelResponse = Mockery::mock(EHealthResponse::class);
+        $cancelResponse->shouldReceive('successful')->andReturn(true);
+        $cancelResponse->shouldReceive('getData')->andReturn(['status' => 'entered-in-error']);
+        $mockServiceApi->shouldReceive('cancel')->once()->andReturn($cancelResponse);
+        $this->instance(ServiceRequestApi::class, $mockServiceApi);
+
+        // Mock SignatureService
+        $mockSignatureService = Mockery::mock(\App\Services\SignatureService::class);
+        $this->instance(\App\Services\SignatureService::class, $mockSignatureService);
+        $mockSignatureService->shouldReceive('signData')->andReturn('mock-base64-signature');
+        $mockSignatureService->shouldReceive('getCertificateAuthorities')->andReturn([]);
+
+        // Livewire test
+        Livewire::test(CarePlanShow::class, ['carePlan' => $carePlan])
+            ->call('cancelReferral', $uuid, 'service_request')
+            ->assertSet('showSignatureModal', true)
+            ->assertSet('referralRequestIdToSign', $uuid)
+            ->assertSet('actionType', 'cancel_referral')
+            ->set('statusReason', 'entered-in-error')
+            ->set('form.password', '12345678')
+            ->set('form.knedp', 'acsk_test')
+            ->set('form.keyContainerUpload', \Illuminate\Http\UploadedFile::fake()->create('key.dat', 10))
+            ->call('signCancelReferral')
+            ->assertSet('showSignatureModal', false);
+
+        // Assert database updated
+        $this->assertDatabaseHas('service_request_requests', [
+            'uuid' => $uuid,
+            'status' => 'entered-in-error'
+        ]);
+    }
+}


### PR DESCRIPTION
Resolves #267

### Description
This pull request introduces the final polishing and integrations for both Electronic Prescriptions (MedicationRequests) and Electronic Referrals (ServiceRequests & DeviceRequests) associated with Care Plan Activities.

### Key Changes
1. **Care Plan Activity Status Synchronization**:
   - Updated the signing logic (`signEPrescription` and `signReferral`) to transition the target activity's status to `'in-progress'` locally once it is signed and successfully created on eHealth.
2. **OTP / Auth Method Persistence**:
   - Added `inform_with` to the `medication_request_requests` table via database migrations.
   - Persisted the patient's preferred communication/verification method (`OTP` / `inform_with`) during the request creation stage and automatically retrieved it when generating the signature payload.
3. **Interactive Cancellation with KEP**:
   - Converted instant cancellation to a secure signing flow. Doctors are now prompted to choose a cancellation reason from the eHealth status reasons dictionary and sign the cancellation request using their KEP.
4. **Clinical Grounds (Supporting Info) Matching**:
   - Mapped `reasonReferences` from Care Plan Activities and pre-filled them in the electronic referral forms as read-only clinical justifications.
5. **Printable Referral Forms ("Пам'ятка")**:
   - Added a print button for active referrals in the care plan UI, utilizing Alpine.js to fetch printable content and trigger the browser print dialog.
6. **eHealth Error Handling**:
   - Caught `EHealthValidationException` and surfaced user-friendly, translated eHealth validation errors in the frontend instead of generic exceptions.
7. **Robust Testing**:
   - Added comprehensive feature tests in `MedicationRequestLifecycleTest` and `ReferralLifecycleTest` validating creation, KEP signing, and interactive cancellations.
