### PR TITLE
#190: add and modify db tables for update person data

### DIFF
--- a/app/Enums/JobStatus.php
+++ b/app/Enums/JobStatus.php
@@ -14,6 +14,7 @@ enum JobStatus: string
     case SUSPENDED = 'SUSPENDED';
     case PARTIAL = 'PARTIAL';
     case PROCESSING = 'PROCESSING';
+    case PROCESSED = 'PROCESSED';
     case PAUSED = 'PAUSED';
     case COMPLETED = 'COMPLETED';
     case FAILED = 'FAILED';
@@ -24,6 +25,7 @@ enum JobStatus: string
             self::PENDING => 'Очікується',
             self::SUSPENDED => 'Призупинено',
             self::PROCESSING => 'Обробляється',
+            self::PROCESSED => 'Оброблено',
             self::PARTIAL => 'Частково виконано',
             self::PAUSED => 'На паузі',
             self::COMPLETED => 'Виконано',

--- a/app/Enums/ResponseStatus.php
+++ b/app/Enums/ResponseStatus.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use App\Traits\EnumUtils;
+
+enum ResponseStatus: string
+{
+    use EnumUtils;
+
+    case SYNC = 'SYNC';
+    case ASYNC = 'ASYNC';
+    case SUCCESS = 'SUCCESS';
+    case NOT_FOUND = 'NOT_FOUND';
+   
+    public function label(): string
+    {
+        return match($this) {
+            self::SYNC => 'Синхронно',
+            self::ASYNC => 'Асинхронно',
+            self::SUCCESS => 'Успішно',
+            self::NOT_FOUND => 'Не знайдено',
+        };
+    }
+
+    public static function only(array $names): array
+    {
+        return collect(self::cases())
+            ->filter(fn ($case) => in_array($case->name, $names, true))
+            ->map(fn ($case) => $case->value)
+            ->values()
+            ->all();
+    }
+}

--- a/app/Models/Approval.php
+++ b/app/Models/Approval.php
@@ -3,8 +3,9 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Approval extends Model
 {
@@ -42,6 +43,16 @@ class Approval extends Model
     public function identifier(): BelongsTo
     {
         return $this->belongsTo(\App\Models\MedicalEvents\Sql\Identifier::class, 'granted_to_id');
+    }
+
+    public function grantedResources(): HasMany
+    {
+        return $this->hasMany(ApprovalGrantedResource::class);
+    }
+
+    public function grantedResourceTypes(): HasMany
+    {
+        return $this->hasMany(ApprovalGrantedResource::class);
     }
 
     public function getGrantedToDetailsAttribute(): array

--- a/app/Models/ApprovalGrantedResource.php
+++ b/app/Models/ApprovalGrantedResource.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ApprovalGrantedResource extends Model
+{
+    protected $table = 'approval_granted_resources';
+
+    protected $fillable = [
+        'approval_id',
+        'granted_to_id'
+    ];
+
+    public function approval(): BelongsTo
+    {
+        return $this->belongsTo(Approval::class);
+    }
+}

--- a/app/Models/ApprovalGrantedResourceTypes.php
+++ b/app/Models/ApprovalGrantedResourceTypes.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ApprovalGrantedResourceTypes extends Model
+{
+    protected $table = 'approval_granted_resource_types';
+
+    protected $fillable = [
+        'approval_id',
+        'codeable_concept_id'
+    ];
+
+    public function approval(): BelongsTo
+    {
+        return $this->belongsTo(Approval::class);
+    }
+}

--- a/app/Models/EhealthJob.php
+++ b/app/Models/EhealthJob.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class EhealthJob extends Model
+{
+    protected $fillable = [
+        'processing_method',
+        'status',
+        'request_data',
+        'response_data',
+        'eta'
+    ];
+
+    protected $casts = [
+        'request_data' => 'array',
+        'response_data' => 'array',
+        'eta' => 'datetime'
+    ];
+
+    public function links(): HasMany
+    {
+        return $this->hasMany(EhealthLink::class, 'ehealth_job_id');
+    }
+}

--- a/app/Models/EhealthLink.php
+++ b/app/Models/EhealthLink.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EhealthLink extends Model
+{
+    protected $fillable = [
+        'linkable_type',
+        'linkable_id',
+        'ehealth_job_id',
+        'entity',
+        'href'
+    ];
+
+    public function linkable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function job(): BelongsTo
+    {
+        return $this->belongsTo(EhealthJob::class);
+    }
+
+    public function processingData(): HasMany
+    {
+        return $this->hasMany(EhealthRequestProcessing::class);
+    }
+}

--- a/app/Models/EhealthRequestProcessing.php
+++ b/app/Models/EhealthRequestProcessing.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EhealthRequestProcessing extends Model
+{
+    protected $fillable = [
+        'response_data'
+    ];
+
+    protected $casts = [
+        'response_data' => 'array'
+    ];
+
+    public function link(): BelongsTo
+    {
+        return $this->belongsTo(EhealthLink::class, 'ehealth_link_id');
+    }
+}

--- a/database/migrations/install/2021_01_01_000000_create_persons_table.php
+++ b/database/migrations/install/2021_01_01_000000_create_persons_table.php
@@ -34,6 +34,7 @@ return new class extends Migration
             $table->string('unzr')->unique()->nullable();
             $table->jsonb('emergency_contact')->nullable();
             $table->boolean('patient_signed')->default(false)->comment("Person's evidence of sign the person request");
+            $table->boolean('is_syncing')->default(false)->comment('Indicates whether the person data is currently being synchronized with an eHealth system');
             $table->boolean('process_disclosure_data_consent')->default(true)->comment("Person's evidence of information about consent to data disclosure");
             $table->date('death_date')->nullable();
             $table->timestamps();

--- a/database/migrations/install/2026_04_17_150000_create_approvals_table.php
+++ b/database/migrations/install/2026_04_17_150000_create_approvals_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('approvals', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            
+            // Polymorphic relation
+            $table->morphs('approvable');
+            
+            $table->foreignId('created_by_id')->nullable()->constrained('identifiers');
+
+            $table->foreignId('granted_to_id')->nullable()->constrained('identifiers');
+            $table->string('granted_to_type')->default('legal_entity');
+            
+            $table->foreignId('granted_by_id')->nullable()->constrained('employees');
+            
+            $table->uuid('authorize_with')->nullable();
+            $table->foreignId('authentication_method_id')->nullable()->constrained('authentication_methods');
+            
+            $table->foreignId('reason_id')->nullable()->constrained('identifiers');
+
+            $table->string('status')->index();
+            $table->string('access_level')->default('read');
+            $table->boolean('is_verified')->default(false);
+            $table->timestamp('expires_at')->nullable();
+
+            $table->timestamps();
+        });
+
+        Schema::create('approval_granted_resources', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('approval_id')->constrained('approvals')->cascadeOnDelete();
+            $table->foreignId('granted_to_id')->nullable()->constrained('identifiers');
+            $table->timestamps();
+        });
+
+        Schema::create('approval_granted_resource_types', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('approval_id')->constrained('approvals')->cascadeOnDelete();
+            $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('approval_granted_resource_types');
+        Schema::dropIfExists('approval_granted_resources');
+        Schema::dropIfExists('approvals');
+    }
+};

--- a/database/migrations/install/2026_06_10_170245_add_ehealth_jobs_table.php
+++ b/database/migrations/install/2026_06_10_170245_add_ehealth_jobs_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Enums\JobStatus;
+use App\Enums\ResponseStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected const array VALID_STATUSES = [
+        'SYNC',
+        'ASYNC'
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+          Schema::create('ehealth_jobs', function (Blueprint $table) {
+            $table->id();
+
+            $table->enum('processing_method', ResponseStatus::only(self::VALID_STATUSES))->default(ResponseStatus::ASYNC)->comment('201 - sync, 202 - async processing method code');
+            $table->enum('status', JobStatus::values())->nullable();
+            
+            $table->json('request_data')->nullable()->comment('original request data sent to eHealth API');
+            $table->json('response_data')->nullable()->comment('response data received from eHealth API');
+            
+            $table->timestamp('eta')->nullable()->comment('estimated time of arrival');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ehealth_jobs');
+    }
+};

--- a/database/migrations/install/2026_06_12_094307_create_ehealth_links_table.php
+++ b/database/migrations/install/2026_06_12_094307_create_ehealth_links_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ehealth_links', function (Blueprint $table) {
+            $table->id();
+
+            $table->morphs('linkable');
+
+            $table->foreignId('ehealth_job_id')->nullable()->constrained('ehealth_jobs')->nullOnDelete();
+
+            $table->string('entity')->nullable();
+
+            $table->text('href')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ehealth_links');
+    }
+};

--- a/database/migrations/install/2026_06_12_094317_create_ehealth_request_processing_table.php
+++ b/database/migrations/install/2026_06_12_094317_create_ehealth_request_processing_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ehealth_request_processing', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('ehealth_link_id')->nullable()
+                ->constrained('ehealth_links')
+                ->nullOnDelete();
+
+            $table->json('response_data')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ehealth_request_processing');
+    }
+};

--- a/database/migrations/update/0_1/2026_04_17_150000_create_approvals_table.php
+++ b/database/migrations/update/0_1/2026_04_17_150000_create_approvals_table.php
@@ -36,8 +36,6 @@ return new class extends Migration {
      */
     public function down(): void
     {
-        if (Schema::hasTable('approvals')) {
-            Schema::dropIfExists('approvals');
-        }
+        Schema::dropIfExists('approvals');
     }
 };

--- a/database/migrations/update/0_1/2026_06_10_093512_add_person_data_update_status_attribute_to_person_table.php
+++ b/database/migrations/update/0_1/2026_06_10_093512_add_person_data_update_status_attribute_to_person_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('persons', static function (Blueprint $table) {
+            if (!Schema::hasColumn('persons', 'is_syncing')) {
+                $table->boolean('is_syncing')->default(false)->comment('Indicates whether the person data is currently being synchronized with an eHealth system');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('persons', static function (Blueprint $table) {
+            if (Schema::hasColumn('persons', 'is_syncing')) {
+                $table->dropColumn('is_syncing');
+            }
+        });
+    }
+};

--- a/database/migrations/update/0_1/2026_06_10_170245_add_ehealth_jobs_table.php
+++ b/database/migrations/update/0_1/2026_06_10_170245_add_ehealth_jobs_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Enums\JobStatus;
+use App\Enums\ResponseStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected const array VALID_STATUSES = [
+        'SYNC',
+        'ASYNC'
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('ehealth_jobs')) {
+            Schema::create('ehealth_jobs', function (Blueprint $table) {
+                $table->id();
+
+                $table->enum('processing_method', ResponseStatus::only(self::VALID_STATUSES))->default(ResponseStatus::ASYNC)->comment('201 - sync, 202 - async processing method code');
+                $table->enum('status', JobStatus::values())->nullable();
+                
+                $table->json('request_data')->nullable()->comment('original request data sent to eHealth API');
+                $table->json('response_data')->nullable()->comment('response data received from eHealth API');
+                
+                $table->timestamp('eta')->nullable()->comment('estimated time of arrival');
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ehealth_jobs');
+    }
+};

--- a/database/migrations/update/0_1/2026_06_12_094307_create_ehealth_links_table.php
+++ b/database/migrations/update/0_1/2026_06_12_094307_create_ehealth_links_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Enums\JobStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('ehealth_links')) {
+            Schema::create('ehealth_links', function (Blueprint $table) {
+                $table->id();
+
+                $table->morphs('linkable');
+
+                $table->foreignId('ehealth_job_id')->nullable()->constrained('ehealth_jobs')->nullOnDelete();
+
+                $table->string('entity')->nullable();
+
+                $table->text('href')->nullable();
+
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ehealth_links');
+    }
+};

--- a/database/migrations/update/0_1/2026_06_12_094317_create_ehealth_request_processing_table.php
+++ b/database/migrations/update/0_1/2026_06_12_094317_create_ehealth_request_processing_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('ehealth_request_processing')) {
+            Schema::create('ehealth_request_processing', function (Blueprint $table) {
+                $table->id();
+
+                $table->foreignId('ehealth_link_id')->nullable()
+                    ->constrained('ehealth_links')
+                    ->nullOnDelete();
+
+                $table->json('response_data')->nullable();
+
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ehealth_request_processing');
+    }
+};

--- a/database/migrations/update/0_1/2026_06_12_183800_create_additional_approvals_tables.php
+++ b/database/migrations/update/0_1/2026_06_12_183800_create_additional_approvals_tables.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('approvals', static function (Blueprint $table) {
+            if (!Schema::hasColumn('approvals', 'created_by_id')) {
+                $table->foreignId('created_by_id')->nullable()->constrained('identifiers');
+            }
+
+            if (!Schema::hasColumn('approvals', 'authorize_with')) {
+                $table->uuid('authorize_with')->nullable();
+            }
+            
+            if (!Schema::hasColumn('approvals', 'authentication_method_id')) {
+                $table->foreignId('authentication_method_id')->nullable()->constrained('authentication_methods');
+            }
+
+            if (!Schema::hasColumn('approvals', 'access_level')) {
+                $table->string('access_level')->default('read');
+            }
+
+            if (!Schema::hasColumn('approvals', 'is_verified')) {
+                $table->boolean('is_verified')->default(false);
+            }
+            
+            if (!Schema::hasColumn('approvals', 'expires_at')) {
+                $table->timestamp('expires_at')->nullable();
+            }
+        });
+
+        if (!Schema::hasTable('approval_granted_resources')) {
+            Schema::create('approval_granted_resources', static function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('approval_id')->constrained('approvals')->cascadeOnDelete();
+                $table->foreignId('granted_to_id')->nullable()->constrained('identifiers');
+                $table->timestamps();
+            });
+        }
+
+        if (!Schema::hasTable('approval_granted_resource_types')) {
+            Schema::create('approval_granted_resource_types', static function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('approval_id')->constrained('approvals')->cascadeOnDelete();
+                $table->foreignId('codeable_concept_id')->constrained('codeable_concepts')->cascadeOnDelete();
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('approval_granted_resource_types');
+        Schema::dropIfExists('approval_granted_resources');
+
+        Schema::table('approvals', static function (Blueprint $table) {
+            if (Schema::hasColumn('approvals', 'created_by_id')) {
+                $table->dropForeign(['created_by_id']);
+                $table->dropColumn('created_by_id');
+            }
+
+            if (Schema::hasColumn('approvals', 'authorize_with')) {
+                $table->dropColumn('authorize_with');
+            }
+            
+            if (Schema::hasColumn('approvals', 'authentication_method_id')) {
+                $table->dropForeign(['authentication_method_id']);
+                $table->dropColumn('authentication_method_id');
+            }
+
+            if (Schema::hasColumn('approvals', 'access_level')) {
+                $table->dropColumn('access_level');
+            }
+
+            if (Schema::hasColumn('approvals', 'is_verified')) {
+                $table->dropColumn('is_verified');
+            }
+            
+            if (Schema::hasColumn('approvals', 'expires_at')) {
+                $table->dropColumn('expires_at');
+            }
+        });
+    }
+};


### PR DESCRIPTION
This PR concerns the #190 ISSUE

Що було зроблено:
- додано атрибут (колонку) `is_syncing`  до таблиці persons - який відповідає за "сигнаглізацію" того, що зараз йде синхронізація персональних даних пацієнта (щоб не запустити одночасно декілька процесів синхронізації);
- додано створення таблиці `approvals `під час інсталяції системи;
- додано міграцію з модифікаціями наявної таблиці `approvals`;
- додано додаткові таблиці, які пов'язані з approvals: `granted_resources` і `granted_resource_types`;
- створено структуру даних для віддалених джобів eHealth: EhealthJob, EhealthLink, EhealthRequestProcessing.