### PR TITLE
i111 upd employee registration and first login flow

### DIFF
--- a/app/Http/Controllers/Auth/EHealthLoginController.php
+++ b/app/Http/Controllers/Auth/EHealthLoginController.php
@@ -13,10 +13,10 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use App\Events\EHealthUserLogin;
 use App\Mail\UserCredentialsMail;
-use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Session;
@@ -211,13 +211,21 @@ class EHealthLoginController extends Controller
         if (!$user) {
             $password = Str::random(8);
 
-            // When the user try login to eHealth directly without having a local user account
             $user = User::forceCreate([
                 'uuid' => $ehealthUserId,
                 'email' => $ehealthEmail,
                 'password' => Hash::make($password),
-                'inserted_at' => Carbon::parse($ehealthInsertedAt)->setTimezone(config('app.timezone'))->format('Y-m-d H:i:s'),
-                'email_verified_at' => now()
+                'inserted_at' => Carbon::parse($ehealthInsertedAt)
+                    ->setTimezone(config('app.timezone'))
+                    ->format('Y-m-d H:i:s'),
+                'email_verified_at' => now(),
+                'must_change_password' => true,
+            ]);
+
+            Log::info('Local user account was created during eHealth login.', [
+                'user_id' => $user->id,
+                'email' => $ehealthEmail,
+                'ehealth_user_id' => $ehealthUserId,
             ]);
 
             try {

--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Features\SupportRedirects\Redirector;
@@ -85,6 +86,18 @@ class Login extends Component
         $key = $this->throttleKey();
 
         $credentials = $this->validate();
+
+        $user = User::where('email', $credentials['email'])->first();
+
+        if ($user && $user->mustChangePassword) {
+            $this->clearLoginAttempts();
+            $token = Password::createToken($user);
+        
+            return redirect()->route('password.reset', [
+                'token' => $token,
+                'email' => $user->email,
+            ]);
+        }
 
         // This need to avoid further user authentication for local auth
         if (!empty($this->legalEntityUuid)) {

--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -51,7 +51,8 @@ class ResetPassword extends Component
             $data,
             function ($user) {
                 $user->forceFill([
-                    'password' => Hash::make($this->password)
+                    'password' => Hash::make($this->password),
+                    'must_change_password' => false,
                 ])->save();
 
                 event(new PasswordReset($user));
@@ -63,7 +64,7 @@ class ResetPassword extends Component
          * the application's home authenticated view. If there is an error we can
          * redirect them back to where they came from with their error message.
          */
-        if ($status != Password::PasswordReset) {
+        if ($status != Password::PASSWORD_RESET) {
             Log::error('Reset password:', ['email' => $this->email, 'status' => __($status)]);
 
             session()->flash('error', __('auth.login.error.reset_password'));

--- a/app/Livewire/Employee/AbstractEmployeeFormManager.php
+++ b/app/Livewire/Employee/AbstractEmployeeFormManager.php
@@ -18,18 +18,23 @@ use App\Exceptions\EHealth\EHealthValidationException;
 use App\Models\Employee\BaseEmployee;
 use App\Models\Employee\Employee;
 use App\Models\Employee\EmployeeRequest;
+use App\Repositories\Repository;
 use App\Models\LegalEntity;
 use App\Models\Revision;
 use App\Models\User;
 use Auth;
 use Carbon\Carbon;
 use Exception;
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\WithFileUploads;
+use App\Mail\UserCredentialsMail;
 use RuntimeException;
 use Throwable;
 
@@ -136,6 +141,8 @@ abstract class AbstractEmployeeFormManager extends EmployeeComponent
 
             $this->updateLocalRecords($requestToSign, $validatedData);
 
+            $this->createLocalUserForEmployeeRequest($requestToSign);
+
             session()?->flash('success', __('employees.sign_success'));
             $this->resetSignatureFields();
             Log::info('Successfully signed and will redirect.');
@@ -154,6 +161,65 @@ abstract class AbstractEmployeeFormManager extends EmployeeComponent
 
             $this->dispatch('flashMessage', ['message' => __('errors.unexpected_error'), 'type' => 'error', 'persistent' => true]);
             $this->dispatch('close-signature-modal');
+        }
+    }
+
+    protected function createLocalUserForEmployeeRequest(EmployeeRequest $employeeRequest): void
+    {
+        $email = $employeeRequest->email;
+
+        if (empty($email)) {
+            Log::warning('Employee request user was not created because email is empty.', [
+                'employee_request_id' => $employeeRequest->id,
+            ]);
+
+            return;
+        }
+
+        $existingUser = User::where('email', $email)->first();
+
+        if ($existingUser) {
+            $employeeRequest->update([
+                'user_id' => $existingUser->id,
+            ]);
+
+            Log::info('Employee request linked to existing user. Credentials email was not sent.', [
+                'employee_request_id' => $employeeRequest->id,
+                'user_id' => $existingUser->id,
+                'email' => $email,
+            ]);
+
+            return;
+        }
+
+        $password = Str::random(8);
+
+        $user = User::forceCreate([
+            'email' => $email,
+            'password' => Hash::make($password),
+            'email_verified_at' => now(),
+            'must_change_password' => true,
+        ]);
+
+        $employeeRequest->update([
+            'user_id' => $user->id,
+        ]);
+
+        try {
+            Mail::to($user->email)->send(new UserCredentialsMail($user->email, $password));
+
+            Log::info('Employee request user credentials email sent.', [
+                'employee_request_id' => $employeeRequest->id,
+                'user_id' => $user->id,
+                'email' => $user->email,
+            ]);
+        } catch (Exception $e) {
+            Log::error('Failed to send credentials email to user.', [
+                'employee_request_id' => $employeeRequest->id,
+                'user_id' => $user->id,
+                'user_email' => $user->email,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 
@@ -271,7 +337,7 @@ abstract class AbstractEmployeeFormManager extends EmployeeComponent
             $errorCode === 422 && str_contains($errorMessage, 'tax_id')
             => __('errors.ehealth.messages.tax_id_exists'),
 
-            default => $e->getTranslatedMessage()
+            default => $errorMessage
         };
 
         $this->dispatch('flashMessage', [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,7 +66,8 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'secret_key',
         'party_id',
-        'inserted_at'
+        'inserted_at',
+        'must_change_password',
     ];
 
     /**
@@ -87,7 +88,8 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
-        'two_factor_code_expires_at' => 'immutable_datetime'
+        'two_factor_code_expires_at' => 'immutable_datetime',
+        'must_change_password' => 'boolean'
     ];
 
     /**

--- a/database/migrations/install/2025_12_10_000088_create_users_table.php
+++ b/database/migrations/install/2025_12_10_000088_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->boolean('must_change_password')->default(false);
             $table->rememberToken();
             $table->string('two_factor_code')->nullable();
             $table->timestamp('two_factor_code_expires_at')->nullable();

--- a/database/migrations/update/0_1/2026_06_09_104016_add_must_change_password_to_users_table.php
+++ b/database/migrations/update/0_1/2026_06_09_104016_add_must_change_password_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasColumn('users', 'must_change_password')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->boolean('must_change_password')
+                    ->default(false)
+                    ->after('password');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('users', 'must_change_password')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->dropColumn('must_change_password');
+            });
+        }
+    }
+};

--- a/resources/views/livewire/employee/parts/modals/signature-modal.blade.php
+++ b/resources/views/livewire/employee/parts/modals/signature-modal.blade.php
@@ -59,7 +59,7 @@
                                         wire:model="form.keyContainerUpload"
                                     >
                                 </div>
-{{--                                <div class="mt-1 text-sm text-gray-500 dark:text-gray-300" id="file_help">{{ __('forms.key_file_description') ?? 'Upload your key file to sign the document.' }}</div>--}}
+                                <div class="mt-1 text-sm text-gray-500 dark:text-gray-300" id="file_help">{{ __('forms.key_file_description') ?? 'Upload your key file to sign the document.' }}</div>
                                 <div wire:loading wire:target="form.keyContainerUpload" class="text-sm text-gray-500 mt-2">Uploading...</div>
                             </x-slot>
                             @error("form.keyContainerUpload")<x-forms.error>{{ $message }}</x-forms.error>@enderror


### PR DESCRIPTION
Related #111 

- Updated the local user creation flow after signing an employee request.
- Added email sending with login credentials and a temporary password.
- Added the must_change_password field for users.
- Added mandatory temporary password change on first login.
- Removed self-registration from the login page.