### PR TITLE
I278 diagnostic reports edit

### DIFF
--- a/app/Livewire/DiagnosticReport/DiagnosticReportComponent.php
+++ b/app/Livewire/DiagnosticReport/DiagnosticReportComponent.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire\DiagnosticReport;
 
 use App\Classes\Cipher\Traits\Cipher;
+use App\Enums\Person\DiagnosticReportStatus;
+use App\Services\MedicalEvents\Fhir;
 use App\Livewire\DiagnosticReport\Forms\DiagnosticReportForm as Form;
 use App\Models\Employee\Employee;
 use App\Models\Icd10;
@@ -13,6 +15,7 @@ use App\Models\Person\Person;
 use App\Traits\FormTrait;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Livewire\WithFileUploads;
@@ -227,5 +230,37 @@ class DiagnosticReportComponent extends Component
                 $value[0] => $this->dictionaries[$value[0]] ?? []
             ])
             ->toArray();
+    }
+
+    /**
+     * Prepare formatted data.
+     *
+     * @param  array  $validatedData
+     * @param  DiagnosticReportStatus $status
+     * @param  string|null $diagnosticReportUuid
+     * @return array
+     */
+    protected function prepareFormattedData(array $validatedData, DiagnosticReportStatus $status, ?string $diagnosticReportUuid = null): array 
+    {
+        $uuids = [
+            'employee' => Auth::user()->getDiagnosticReportWriterEmployee()->uuid,
+            'diagnosticReport' => $diagnosticReportUuid ?? Str::uuid()->toString(),
+        ];
+
+        $diagnosticReport = Fhir::diagnosticReport()->toFhir(
+            $validatedData['diagnosticReport'],
+            $uuids,
+            $status
+        );
+
+        $observations = collect($validatedData['observations'] ?? [])
+            ->map(fn (array $observation) => Fhir::observation()->toFhir($observation, $uuids))
+            ->values()
+            ->toArray();
+
+        return [
+            'diagnosticReport' => $diagnosticReport,
+            'observations' => $observations,
+        ];
     }
 }

--- a/app/Livewire/DiagnosticReport/DiagnosticReportCreate.php
+++ b/app/Livewire/DiagnosticReport/DiagnosticReportCreate.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Livewire\DiagnosticReport;
 
 use App\Classes\eHealth\EHealth;
+use App\Classes\Cipher\Api\CipherRequest;
 use App\Exceptions\EHealth\EHealthConnectionException;
 use App\Exceptions\EHealth\EHealthException;
+use App\Exceptions\Cipher\CipherConnectionException;
+use App\Exceptions\Cipher\CipherException;
 use App\Enums\Person\DiagnosticReportStatus;
 use App\Models\MedicalEvents\Sql\DiagnosticReport;
-use App\Services\MedicalEvents\Fhir;
 use App\Core\Arr;
 use App\Repositories\MedicalEvents\Repository;
 use Exception;
@@ -17,7 +19,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\ValidationException;
-use Illuminate\Support\Str;
 use Throwable;
 
 class DiagnosticReportCreate extends DiagnosticReportComponent
@@ -56,7 +57,7 @@ class DiagnosticReportCreate extends DiagnosticReportComponent
         $formattedData = $this->prepareFormattedData($validated, DiagnosticReportStatus::DRAFT);
 
         try {
-            $this->storeValidatedData($formattedData);
+            $diagnosticReportId = $this->storeValidatedData($formattedData);
         } catch (Exception|Throwable $exception) {
             $this->handleDatabaseErrors($exception, 'Error while saving diagnostic report');
 
@@ -64,7 +65,15 @@ class DiagnosticReportCreate extends DiagnosticReportComponent
         }
 
         Session::flash('success', __('patients.messages.diagnostic_report_draft_saved'));
-        $this->redirectRoute('persons.index', [legalEntity()], navigate: true);
+        $this->redirectRoute(
+            'diagnostic-report.edit',
+            [
+                legalEntity(),
+                'personId' => $this->personId,
+                'diagnosticReportId' => $diagnosticReportId,
+            ],
+            navigate: true
+        );
     }
 
     /**
@@ -76,7 +85,7 @@ class DiagnosticReportCreate extends DiagnosticReportComponent
     public function sign(array $diagnosticReportData): void
     {
         if (Auth::user()->cannot('create', DiagnosticReport::class)) {
-            Session::flash('error', __('patient.policy.create_diagnostic_report'));
+            Session::flash('error', __('patients.policy.create_diagnostic_report'));
 
             return;
         }
@@ -96,26 +105,34 @@ class DiagnosticReportCreate extends DiagnosticReportComponent
         $formattedData = $this->prepareFormattedData($validated, DiagnosticReportStatus::FINAL);
 
         try {
-            $signedContent = signatureService()->signData(
+            $signedContent = new CipherRequest()->signData(
                 Arr::toSnakeCase($formattedData),
-                $validatedCipher['password'],
                 $validatedCipher['knedp'],
                 $validatedCipher['keyContainerUpload'],
+                $validatedCipher['password'],
                 Auth::user()->party->taxId
             );
-        } catch (Throwable $exception) {
-            Session::flash('error', $exception->getMessage());
+        } catch (CipherException|CipherConnectionException $exception) {
+            $exception->handle('Error when signing diagnostic report with Cipher');
 
             return;
         }
 
         try {
-            EHealth::diagnosticReport()->create($this->patientUuid, ['signed_data' => $signedContent]);
+            EHealth::diagnosticReport()->create($this->patientUuid, ['signed_data' => $signedContent->getBase64Data()]);
 
-            $this->storeValidatedData($formattedData);
+            $diagnosticReportId = $this->storeValidatedData($formattedData);
 
             Session::flash('success', __('patients.messages.diagnostic_report_create_request_sent'));
-            $this->redirectRoute('persons.index', [legalEntity()], navigate: true);
+            $this->redirectRoute(
+                'diagnostic-report.edit',
+                [
+                    legalEntity(),
+                    'personId' => $this->personId,
+                    'diagnosticReportId' => $diagnosticReportId,
+                ],
+                navigate: true
+            );
         } catch (EHealthException|EHealthConnectionException $exception) {
             $exception->handle('Error when creating a diagnostic report');
 
@@ -128,51 +145,22 @@ class DiagnosticReportCreate extends DiagnosticReportComponent
     }
 
     /**
-     * Prepare formatted data.
-     *
-     * @param  array  $validatedData
-     * @param  DiagnosticReportStatus $status
-     * @return array
-     */
-    protected function prepareFormattedData(array $validatedData, DiagnosticReportStatus $status): array
-    {
-        $uuids = [
-            'employee' => Auth::user()->getDiagnosticReportWriterEmployee()->uuid,
-            'diagnosticReport' => Str::uuid()->toString(),
-        ];
-
-        $diagnosticReport = Fhir::diagnosticReport()->toFhir(
-            $validatedData['diagnosticReport'],
-            $uuids,
-            $status
-        );
-
-        $observations = collect($validatedData['observations'] ?? [])
-            ->map(fn (array $observation) => Fhir::observation()->toFhir($observation, $uuids))
-            ->values()
-            ->toArray();
-
-        return [
-            'diagnosticReport' => $diagnosticReport,
-            'observations' => $observations,
-        ];
-    }
-
-    /**
      * Store validated formatted data into DB.
      *
      * @param  array  $formattedData
-     * @return void
+     * @return int
      * @throws Throwable
      */
-    protected function storeValidatedData(array $formattedData): void
+    protected function storeValidatedData(array $formattedData): int
     {
-        DB::transaction(function () use ($formattedData) {
+        return DB::transaction(function () use ($formattedData) {
             $diagnosticReportId = Repository::diagnosticReport()->store([$formattedData['diagnosticReport']], $this->personId);
 
             if (isset($formattedData['observations'])) {
                 Repository::observation()->store($formattedData['observations'], $this->personId, diagnosticReportId: $diagnosticReportId);
             }
+
+            return $diagnosticReportId;
         });
     }
 }

--- a/app/Livewire/DiagnosticReport/DiagnosticReportEdit.php
+++ b/app/Livewire/DiagnosticReport/DiagnosticReportEdit.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\DiagnosticReport;
+
+use App\Classes\eHealth\EHealth;
+use App\Classes\Cipher\Api\CipherRequest;
+use App\Core\Arr;
+use App\Enums\Person\DiagnosticReportStatus;
+use App\Exceptions\EHealth\EHealthConnectionException;
+use App\Exceptions\EHealth\EHealthException;
+use App\Exceptions\Cipher\CipherConnectionException;
+use App\Exceptions\Cipher\CipherException;
+use App\Models\LegalEntity;
+use App\Models\MedicalEvents\Sql\DiagnosticReport;
+use App\Repositories\MedicalEvents\Repository;
+use App\Services\MedicalEvents\Fhir;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
+use Throwable;
+
+class DiagnosticReportEdit extends DiagnosticReportComponent
+{
+    #[Locked]
+    public string $diagnosticReportId;
+
+    #[Locked]
+    public string $diagnosticReportUuid;
+
+    public function mount(LegalEntity $legalEntity, int $personId, ?string $diagnosticReportId = null): void 
+    {
+        parent::mount($legalEntity, $personId);
+        $this->diagnosticReportId = $diagnosticReportId;
+        $diagnosticReport = DiagnosticReport::withAllRelations()
+            ->whereKey($diagnosticReportId)
+            ->where('person_id', $personId)
+            ->firstOrFail();
+
+        $this->diagnosticReportUuid = $diagnosticReport->uuid;
+
+        $diagnosticReportData = Fhir::diagnosticReport()->fromFhir(
+            $diagnosticReport->toArray()
+        );
+
+        $conclusionCode = data_get($diagnosticReportData, 'conclusionCode');
+
+        if ($conclusionCode) {
+            $icd10Items = [
+                [
+                    'codeSystem' => 'eHealth/ICD10_AM/condition_codes',
+                    'codeCode' => $conclusionCode,
+                ],
+            ];
+
+            $this->loadIcd10Descriptions($icd10Items);
+
+            $description = $this->dictionaries['eHealth/ICD10_AM/condition_codes'][$conclusionCode] ?? null;
+
+            $diagnosticReportData['conclusionCodeLabel'] = $description
+                ? $conclusionCode . ' - ' . $description
+                : $conclusionCode;
+        }
+
+        $this->form->diagnosticReport = $diagnosticReportData;
+        $this->form->observations = collect(Repository::observation()->getByDiagnosticReportId($diagnosticReportId))
+            ->map(fn (array $observation) => Fhir::observation()->fromFhir($observation))
+            ->toArray();
+    }
+
+    public function save(array $diagnosticReportData): void
+    {
+        $formattedData = $this->buildFormattedData($diagnosticReportData, DiagnosticReportStatus::DRAFT);
+
+        if ($formattedData === null) {
+            return;
+        }
+
+        try {
+            $this->syncValidatedData($formattedData);
+        } catch (Throwable $exception) {
+            $this->handleDatabaseErrors($exception, 'Error while updating diagnostic report');
+
+            return;
+        }
+
+        Session::flash('success', __('patients.messages.diagnostic_report_draft_saved'));
+
+        $this->redirectRoute(
+            'diagnostic-report.edit',
+            [legalEntity(), 'personId' => $this->personId, 'diagnosticReportId' => $this->diagnosticReportId],
+            navigate: true
+        );
+    }
+
+    public function sign(array $diagnosticReportData): void
+    {
+        try {
+            $validatedCipher = $this->form->validate($this->form->signingRules());
+        } catch (ValidationException $exception) {
+            Session::flash('error', $exception->validator->errors()->first());
+            $this->setErrorBag($exception->validator->getMessageBag());
+
+            return;
+        }
+
+        $formattedData = $this->buildFormattedData($diagnosticReportData, DiagnosticReportStatus::FINAL);
+
+        if ($formattedData === null) {
+            return;
+        }
+
+        try {
+            $signedContent = new CipherRequest()->signData(
+                Arr::toSnakeCase($formattedData),
+                $validatedCipher['knedp'],
+                $validatedCipher['keyContainerUpload'],
+                $validatedCipher['password'],
+                Auth::user()->party->taxId
+            );
+        } catch (CipherException|CipherConnectionException $exception) {
+            $exception->handle('Error when signing diagnostic report with Cipher');
+
+            return;
+        }
+
+        try {
+            EHealth::diagnosticReport()->create($this->patientUuid, ['signed_data' => $signedContent->getBase64Data()]);
+
+            $this->syncValidatedData($formattedData);
+
+            Session::flash('success', __('patients.messages.diagnostic_report_create_request_sent'));
+            $this->redirectRoute(
+                'diagnostic-report.edit',
+                [legalEntity(), 'personId' => $this->personId, 'diagnosticReportId' => $this->diagnosticReportId],
+                navigate: true
+            );
+        } catch (EHealthException|EHealthConnectionException $exception) {
+            $exception->handle('Error when signing diagnostic report');
+
+            return;
+        } catch (Throwable $exception) {
+            $this->handleDatabaseErrors($exception, 'Error while saving diagnostic report');
+
+            return;
+        }
+    }
+
+    private function buildFormattedData(array $diagnosticReportData, DiagnosticReportStatus $status): ?array 
+    {
+        $this->form->diagnosticReport = $diagnosticReportData;
+
+        try {
+            $validated = $this->form->validate();
+        } catch (ValidationException $exception) {
+            Session::flash('error', $exception->validator->errors()->first());
+            $this->setErrorBag($exception->validator->getMessageBag());
+
+            return null;
+        }
+
+        return $this->prepareFormattedData($validated, $status, $this->diagnosticReportUuid);
+    }
+
+    protected function syncValidatedData(array $formattedData): void
+    {
+        DB::transaction(function () use ($formattedData) {
+            Repository::diagnosticReport()->sync(
+                $this->personId,
+                [$this->fhirToSync($formattedData['diagnosticReport'])]
+            );
+
+            Repository::observation()->sync(
+                $this->personId,
+                array_map($this->fhirToSync(...), $formattedData['observations'] ?? [])
+            );
+        });
+    }
+
+    private function fhirToSync(array $fhirItem): array
+    {
+        return Arr::toSnakeCase(
+            collect($fhirItem)
+                ->put('uuid', $fhirItem['id'])
+                ->forget(['id'])
+                ->all()
+        );
+    }
+}

--- a/app/Livewire/DiagnosticReport/Forms/DiagnosticReportForm.php
+++ b/app/Livewire/DiagnosticReport/Forms/DiagnosticReportForm.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Livewire\DiagnosticReport\Forms;
 
-use App\Rules\InDictionary;
 use App\Core\BaseForm;
+use App\Rules\AfterOrEqualDateTime;
+use App\Rules\InDictionary;
+use App\Rules\PastDateTime;
+use Carbon\CarbonImmutable;
+use Closure;
 use Illuminate\Validation\Rule;
 
 class DiagnosticReportForm extends BaseForm
@@ -58,27 +62,67 @@ class DiagnosticReportForm extends BaseForm
                 'date',
             ],
             'diagnosticReport.paperReferralNote' => ['nullable', 'string', 'max:255'],
-            'diagnosticReport.effectivePeriodStartDate' => ['nullable', 'date', 'before_or_equal:now',],
-            'diagnosticReport.effectivePeriodStartTime' => ['nullable', 'date_format:H:i', 'before_or_equal:now'],
+            'diagnosticReport.effectivePeriodStartDate' => [
+                'nullable',
+                'date_format:' . config('app.date_format'),
+                'before_or_equal:today',
+            ],
+            'diagnosticReport.effectivePeriodStartTime' => [
+                'nullable',
+                'date_format:H:i',
+                new PastDateTime(data_get($this->diagnosticReport, 'effectivePeriodStartDate', '')),
+            ],
             'diagnosticReport.effectivePeriodEndDate' => [
                 'nullable',
-                'date',
+                'date_format:' . config('app.date_format'),
                 'before_or_equal:today',
-                'after_or_equal:diagnosticReport.effectivePeriodStartDate'
+                'after_or_equal:diagnosticReport.effectivePeriodStartDate',
             ],
             'diagnosticReport.effectivePeriodEndTime' => [
                 'nullable',
                 'date_format:H:i',
-                function ($attribute, $value, $fail) {
-                    $now = now()->format('H:i');
-                    if ($value > $now) {
-                        $fail('Час завершення прийому не може бути в майбутньому.');
+                new PastDateTime(data_get($this->diagnosticReport, 'effectivePeriodEndDate', '')),
+                new AfterOrEqualDateTime(
+                    data_get($this->diagnosticReport, 'effectivePeriodEndDate', ''),
+                    data_get($this->diagnosticReport, 'effectivePeriodStartDate', ''),
+                    data_get($this->diagnosticReport, 'effectivePeriodStartTime', '')
+                ),
+                function (string $attribute, mixed $value, Closure $fail) {
+                    $issuedDate = data_get($this->diagnosticReport, 'issuedDate');
+                    $issuedTime = data_get($this->diagnosticReport, 'issuedTime');
+                    $endDate = data_get($this->diagnosticReport, 'effectivePeriodEndDate');
+
+                    if (empty($issuedDate) || empty($issuedTime) || empty($endDate) || empty($value)) {
+                        return;
+                    }
+
+                    $end = CarbonImmutable::createFromFormat(
+                        config('app.date_format') . ' H:i',
+                        $endDate . ' ' . $value
+                    );
+
+                    $issued = CarbonImmutable::createFromFormat(
+                        config('app.date_format') . ' H:i',
+                        $issuedDate . ' ' . $issuedTime
+                    );
+
+                    if ($end->isAfter($issued)) {
+                        $fail(__('validation.before_or_equal', [
+                            'date' => __('validation.attributes.issued'),
+                        ]));
                     }
                 },
-                'after:diagnosticReport.effectivePeriodStartTime'
             ],
-            'diagnosticReport.issuedDate' => ['required', 'date', 'before_or_equal:now'],
-            'diagnosticReport.issuedTime' => ['required', 'date_format:H:i', 'before_or_equal:now'],
+            'diagnosticReport.issuedDate' => [
+                'required',
+                'date_format:' . config('app.date_format'),
+                'before_or_equal:today',
+            ],
+            'diagnosticReport.issuedTime' => [
+                'required',
+                'date_format:H:i',
+                new PastDateTime(data_get($this->diagnosticReport, 'issuedDate', '')),
+            ],
             'diagnosticReport.conclusionCode' => [
                 'nullable',
                 'string',

--- a/app/Livewire/Person/Records/PatientDiagnosticReports.php
+++ b/app/Livewire/Person/Records/PatientDiagnosticReports.php
@@ -12,6 +12,7 @@ use App\Jobs\DiagnosticReportSync;
 use App\Traits\HandlesSyncBatch;
 use App\Models\LegalEntity;
 use App\Models\MedicalEvents\Sql\Episode;
+use App\Models\MedicalEvents\Sql\DiagnosticReport;
 use App\Enums\JobStatus;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Session;
@@ -172,7 +173,7 @@ class PatientDiagnosticReports extends BasePatientComponent
             Session::flash('success', __('patients.messages.diagnostic_reports_synced_successfully'));
         }
 
-        $this->diagnosticReports = Arr::toCamelCase($this->formatDatesForDisplay($validatedData));
+        $this->loadDiagnosticReportsFromDb();
 
         $this->loadEpisodes();
         $this->loadEncounters();
@@ -213,13 +214,22 @@ class PatientDiagnosticReports extends BasePatientComponent
 
     private function loadDiagnosticReportsFromDb(): void
     {
-        $diagnosticReports = Repository::diagnosticReport()->getByPersonId($this->personId);
+        $diagnosticReports = DiagnosticReport::withAllRelations()
+        ->where('person_id', $this->personId)
+        ->get();
 
-        $this->totalEntries = count($diagnosticReports);
+        $this->totalEntries = $diagnosticReports->count();
 
-        $this->diagnosticReports = Arr::toCamelCase(
-            $this->formatDatesForDisplay($diagnosticReports)
-        );
+        $this->diagnosticReports = $diagnosticReports
+            ->map(function (DiagnosticReport $diagnosticReport) {
+                $data = Arr::toCamelCase($diagnosticReport->toArray());
+                $data['id'] = $diagnosticReport->id;
+
+                return $data;
+            })
+            ->toArray();
+
+        $this->diagnosticReports = $this->formatDatesForDisplay($this->diagnosticReports);
     }
 
     private function loadEpisodes(): void

--- a/app/Repositories/MedicalEvents/DiagnosticReportRepository.php
+++ b/app/Repositories/MedicalEvents/DiagnosticReportRepository.php
@@ -49,6 +49,16 @@ class DiagnosticReportRepository extends BaseRepository
             ?->fullName;
     }
 
+    private function getServiceDisplayValue(?string $serviceId): ?string
+    {
+        if (!$serviceId) {
+            return null;
+        }
+
+        return collect(dictionary()->services()->flattened()->toArray())
+            ->firstWhere('id', $serviceId)['name'] ?? null;
+    }
+
     /**
      * Store condition in DB.
      *
@@ -62,7 +72,12 @@ class DiagnosticReportRepository extends BaseRepository
         return DB::transaction(function () use ($data, $personId) {
             foreach ($data as $datum) {
                 $codeValue = $datum['code']['identifier']['value'];
-                $code = Repository::identifier()->store($codeValue);
+
+                $code = Repository::identifier()->store(
+                    $codeValue,
+                    $this->getServiceDisplayValue($codeValue)
+                );
+
                 Repository::codeableConcept()->attach($code, $datum['code']);
 
                 $recordedByValue = $datum['recordedBy']['identifier']['value'];
@@ -262,6 +277,8 @@ class DiagnosticReportRepository extends BaseRepository
                 $existing = $existingDiagnosticReports->get($data['uuid']);
 
                 $basedOn = $this->syncIdentifier($existing, $data['based_on'] ?? null, 'basedOn');
+                $codeValue = data_get($data, 'code.identifier.value');
+                $data['code']['display_value'] = data_get($data, 'code.display_value') ?: $this->getServiceDisplayValue($codeValue);
                 $code = $this->syncIdentifier($existing, $data['code'], 'code');
                 $encounter = $this->syncIdentifier($existing, $data['encounter'] ?? null, 'encounter');
                 $division = $this->syncIdentifier($existing, $data['division'] ?? null, 'division');
@@ -270,6 +287,11 @@ class DiagnosticReportRepository extends BaseRepository
                     $data['conclusion_code'] ?? null,
                     'conclusionCode'
                 );
+                $recordedByData = $data['recorded_by'];
+                $recordedByValue = data_get($recordedByData, 'identifier.value');
+                $recordedByData['display_value'] = data_get($recordedByData, 'display_value') ?: $this->getEmployeeDisplayValue($recordedByValue);
+                $recordedByValue = data_get($data, 'recorded_by.identifier.value');
+                $data['recorded_by']['display_value'] = data_get($data, 'recorded_by.display_value') ?: $this->getEmployeeDisplayValue($recordedByValue);
                 $recordedBy = $this->syncIdentifier($existing, $data['recorded_by'], 'recordedBy');
                 $managingOrganization = $this->syncIdentifier(
                     $existing,
@@ -365,11 +387,20 @@ class DiagnosticReportRepository extends BaseRepository
         $text = $entityData['text'] ?? null;
 
         if (isset($entityData['reference'])) {
+            $referenceValue = data_get($entityData, 'reference.identifier.value');
+
+            $entityData['reference']['display_value'] = data_get($entityData, 'reference.display_value')
+                ?: $this->getEmployeeDisplayValue($referenceValue);
+
             if ($existing && $existing->reference) {
                 $this->updateIdentifier($existing->reference, $entityData['reference']);
                 $referenceId = $existing->reference->id;
             } else {
-                $reference = Repository::identifier()->store($entityData['reference']['identifier']['value']);
+                $reference = Repository::identifier()->store(
+                    $referenceValue,
+                    data_get($entityData, 'reference.display_value')
+                );
+
                 Repository::codeableConcept()->attach($reference, $entityData['reference']);
                 $referenceId = $reference->id;
             }

--- a/app/Repositories/MedicalEvents/ObservationRepository.php
+++ b/app/Repositories/MedicalEvents/ObservationRepository.php
@@ -7,6 +7,7 @@ namespace App\Repositories\MedicalEvents;
 use App\Classes\eHealth\Api\PatientApi;
 use App\Models\MedicalEvents\Sql\Observation;
 use App\Models\MedicalEvents\Sql\ObservationComponent;
+use App\Models\MedicalEvents\Sql\DiagnosticReport;
 use App\Models\MedicalEvents\Sql\Quantity;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -27,6 +28,22 @@ class ObservationRepository extends BaseRepository
         parent::__construct($model);
 
         $this->employeeUuid = Auth::user()?->getDiagnosticReportWriterEmployee()?->uuid;
+    }
+
+    public function getByDiagnosticReportId(string $diagnosticReportId): array
+    {
+        $diagnosticReportUuid = DiagnosticReport::query()
+            ->whereKey($diagnosticReportId)
+            ->value('uuid');
+
+        if (!$diagnosticReportUuid) {
+            return [];
+        }
+
+        return $this->model::withAllRelations()
+            ->whereHas('diagnosticReport', fn (Builder $query) => $query->where('value', $diagnosticReportUuid))
+            ->get()
+            ->toArray();
     }
 
     /**

--- a/resources/lang/uk/validation.php
+++ b/resources/lang/uk/validation.php
@@ -440,10 +440,6 @@ return [
         'division.location.latitude' => 'Широта',
         'division.location.longitude' => 'Довгота',
 
-        // Diagnostic report
-        'diagnosticReport.categoryCode' => 'категорія діагностичного звіту',
-        'diagnosticReport.codeValue' => 'послуга',
-
         // Healthcare Service
         'category.coding.*.code' => 'категорія послуги',
         'type.coding.*.code' => 'тип медичної послуги',
@@ -692,6 +688,30 @@ return [
             'requiredIssuedDate' => __('Дата видачі є обов\'язковою до заповнення'),
             'requiredActiveFromDate' => __('Дата початку дії є обов\'язковою до заповнення'),
             'requiredIssuedBy' => __('Потрібно вказати орган, який видав документ'),
+        ],
+
+        'diagnosticReport' => [
+            'categoryCode' => 'категорія діагностичного звіту',
+            'codeValue' => 'послуга діагностичного звіту',
+            'primarySource' => 'первинне джерело діагностичного звіту',
+            'reportOriginCode' => 'посилання на джерело інформації діагностичного звіту',
+            'reportOriginText' => 'джерело інформації діагностичного звіту',
+            'paperReferralRequisition' => 'номер направлення діагностичного звіту',
+            'paperReferralRequesterEmployeeName' => 'автор направлення діагностичного звіту',
+            'paperReferralRequesterLegalEntityEdrpou' => 'ЄДРПОУ закладу, що виписав направлення діагностичного звіту',
+            'paperReferralRequesterLegalEntityName' => 'найменування закладу, що виписав направлення діагностичного звіту',
+            'paperReferralServiceRequestDate' => 'дата направлення діагностичного звіту',
+            'paperReferralNote' => 'нотатки направлення діагностичного звіту',
+            'conclusionCode' => 'код заключення за МКХ-10АМ діагностичного звіту',
+            'conclusion' => 'заключення діагностичного звіту',
+            'divisionId' => 'місце надання послуг діагностичного звіту',
+            'resultsInterpreterEmployeeId' => 'лікар, що інтерпретував результати діагностичного звіту',
+            'issuedDate' => 'дата внесення діагностичного звіту',
+            'issuedTime' => 'час внесення діагностичного звіту',
+            'effectivePeriodStartDate' => 'дата початку прийому діагностичного звіту',
+            'effectivePeriodStartTime' => 'час початку прийому діагностичного звіту',
+            'effectivePeriodEndDate' => 'дата завершення прийому діагностичного звіту',
+            'effectivePeriodEndTime' => 'час завершення прийому діагностичного звіту',
         ],
 
         'diagnosticReports.*' => [

--- a/resources/views/components/select2.blade.php
+++ b/resources/views/components/select2.blade.php
@@ -124,17 +124,50 @@
                             ? `${rootPath}.categoryCode`
                             : `${rootPath}.category[0].coding[0].code`;
 
-                        this.$watch(categoryPath, (newCode) => {
-                            this.options = Object.entries(rawData)
-                                .filter(([_, service]) => service.category === newCode)
-                                .map(([_, service]) => ({
+                        const setServiceOptions = (categoryCode) => {
+                            const selectedCategory = categoryCode ?? '';
+
+                            this.options = Object.values(rawData)
+                                .filter((service) => {
+                                    if (!selectedCategory) {
+                                        return false;
+                                    }
+
+                                    return (service.category ?? '') === selectedCategory;
+                                })
+                                .map((service) => ({
                                     value: service.id,
                                     code: service.code,
                                     label: service.name,
-                                    searchText: `${service.name} ${service.code}`.toLowerCase()
+                                    searchText: `${service.name ?? ''} ${service.code ?? ''} ${service.id ?? ''}`.toLowerCase()
                                 }));
+
                             this.buildOptionsMap();
+
+                            const selectedOption = this.optionsMap.get(this.selected);
+
+                            if (selectedOption) {
+                                this.search = `[${selectedOption.code ?? selectedOption.value}] - ${selectedOption.label}`;
+                            } else if (this.selected) {
+                                this.search = '';
+                            }
+
                             this.filterOptions();
+                        };
+
+                        const currentCategoryCode = (isModalProcedure || isModalDiagnosticReport)
+                            ? this[rootPath]?.categoryCode
+                            : this[rootPath]?.category?.[0]?.coding?.[0]?.code;
+
+                        setServiceOptions(currentCategoryCode);
+
+                        this.$watch(categoryPath, (newCode, oldCode) => {
+                            setServiceOptions(newCode);
+
+                            if (oldCode !== undefined && newCode !== oldCode && !this.optionsMap.has(this.selected)) {
+                                this.selected = '';
+                                this.search = '';
+                            }
                         });
                     } else {
                         this.options = Object.entries(rawData).map(([value, label]) => this.makeOption(value, label));

--- a/resources/views/livewire/diagnostic-report/diagnostic-report.blade.php
+++ b/resources/views/livewire/diagnostic-report/diagnostic-report.blade.php
@@ -7,7 +7,7 @@
 
     <form class="form"
           x-data="{
-              modalDiagnosticReport: Object.assign(new DiagnosticReport(), { primarySource: true }),
+              modalDiagnosticReport: Object.assign(new DiagnosticReport(), @js($this->form->diagnosticReport ?: ['primarySource' => true])),
               diagnosticReportCategoriesDictionary: $wire.dictionaries['eHealth/diagnostic_report_categories'],
               servicesDictionary: $wire.dictionaries['custom/services'],
               showSignatureModal: false
@@ -76,6 +76,7 @@
             this.paperReferralNote = '';
 
             this.conclusionCode = '';
+            this.conclusionCodeLabel = '';
             this.conclusion = '';
 
             this.primarySource = true;

--- a/resources/views/livewire/encounter/diagnostic-report-parts/additional-information.blade.php
+++ b/resources/views/livewire/encounter/diagnostic-report-parts/additional-information.blade.php
@@ -1,3 +1,9 @@
+@php
+    $diagnosticReportErrorPath = $diagnosticReportErrorPath
+        ?? (($context ?? null) === 'diagnostic-report'
+            ? 'form.diagnosticReport'
+            : 'form.diagnosticReports.*');
+@endphp
 <fieldset class="fieldset">
     <legend class="legend">
         {{ __('forms.additional_info') }}
@@ -87,8 +93,8 @@
                     @endforeach
                 </select>
 
-                @error('form.diagnosticReports.*.divisionId')
-                <p class="text-error">{{ $message }}</p>
+                @error($diagnosticReportErrorPath . '.divisionId')
+                    <p class="text-error">{{ $message }}</p>
                 @enderror
             </div>
         </div>
@@ -112,8 +118,8 @@
                 @endforeach
             </select>
 
-            @error('form.diagnosticReports.*.resultsInterpreterEmployeeId')
-            <p class="text-error">{{ $message }}</p>
+            @error($diagnosticReportErrorPath . '.resultsInterpreterEmployeeId')
+                <p class="text-error">{{ $message }}</p>
             @enderror
         </div>
     </div>
@@ -155,8 +161,8 @@
                     {{ __('patients.date_time_entered') }}
                 </label>
 
-                @error('form.diagnosticReports.*.issuedDate')
-                <p class="text-error">{{ $message }}</p>
+                @error($diagnosticReportErrorPath . '.issuedDate')
+                    <p class="text-error">{{ $message }}</p>
                 @enderror
             </div>
         </div>
@@ -176,8 +182,8 @@
                 >
             </div>
 
-            @error('form.diagnosticReports.*.issuedTime')
-            <p class="text-error">{{ $message }}</p>
+            @error($diagnosticReportErrorPath . '.issuedTime')
+                <p class="text-error">{{ $message }}</p>
             @enderror
         </div>
     </div>
@@ -200,8 +206,8 @@
                     {{ __('patients.reception_start_date_and_time') }}
                 </label>
 
-                @error('form.diagnosticReports.*.effectivePeriodStartDate')
-                <p class="text-error">{{ $message }}</p>
+                @error($diagnosticReportErrorPath . '.effectivePeriodStartDate')
+                    <p class="text-error">{{ $message }}</p>
                 @enderror
             </div>
         </div>
@@ -221,8 +227,8 @@
                 >
             </div>
 
-            @error('form.diagnosticReports.*.effectivePeriodStartTime')
-            <p class="text-error">{{ $message }}</p>
+            @error($diagnosticReportErrorPath . '.effectivePeriodStartTime')
+                <p class="text-error">{{ $message }}</p>
             @enderror
         </div>
     </div>
@@ -245,8 +251,8 @@
                     {{ __('patients.reception_end_date_and_time') }}
                 </label>
 
-                @error('form.diagnosticReports.*.effectivePeriodEndDate')
-                <p class="text-error">{{ $message }}</p>
+                @error($diagnosticReportErrorPath . '.effectivePeriodEndDate')
+                    <p class="text-error">{{ $message }}</p>
                 @enderror
             </div>
         </div>
@@ -266,8 +272,8 @@
                 >
             </div>
 
-            @error('form.diagnosticReports.*.effectivePeriodEndTime')
-            <p class="text-error">{{ $message }}</p>
+            @error($diagnosticReportErrorPath . '.effectivePeriodEndTime')
+                <p class="text-error">{{ $message }}</p>
             @enderror
         </div>
     </div>

--- a/resources/views/livewire/encounter/diagnostic-report-parts/main-information.blade.php
+++ b/resources/views/livewire/encounter/diagnostic-report-parts/main-information.blade.php
@@ -241,7 +241,7 @@
                 selected: null,
                 results: $wire.entangle('results'),
                 showResults: false,
-                conclusionCodeLabel: '',               
+                conclusionCodeLabel: modalDiagnosticReport.conclusionCodeLabel || modalDiagnosticReport.conclusionCode || '',
              }"
              class="form-row-2 relative"
         >
@@ -285,6 +285,7 @@
                                     selected = result;
                                     conclusionCodeLabel = result.code + ' - ' + result.description;
                                     modalDiagnosticReport.conclusionCode = result.code;
+                                    modalDiagnosticReport.conclusionCodeLabel = conclusionCodeLabel;
                                     showResults = false;
                                 "
                             >

--- a/resources/views/livewire/person/records/diagnostic-reports.blade.php
+++ b/resources/views/livewire/person/records/diagnostic-reports.blade.php
@@ -737,12 +737,15 @@
                                          :id="$id('dropdown-button')"
                                          class="absolute right-0 mt-2 w-56 rounded-md bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 shadow-lg z-50 py-1"
                                     >
-                                        <button @click="close($refs.button)"
+                                        @if(!empty(data_get($diagnosticReport, 'id')))
+                                            <a  href="{{ route('diagnostic-report.edit', [legalEntity(), 'personId' => $personId, 'diagnosticReportId' => data_get($diagnosticReport, 'id')]) }}"
+                                                wire:navigate
                                                 class="flex items-center gap-2 w-full px-4 py-2.5 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
-                                        >
-                                            @icon('eye', 'w-5 h-5 text-gray-500')
-                                            {{ __('patients.view_details') }}
-                                        </button>
+                                            >
+                                                @icon('eye', 'w-5 h-5 text-gray-500')
+                                                {{ __('patients.view_details') }}
+                                            </a>
+                                        @endif
 
                                         <button @click="close($refs.button)"
                                                 class="flex items-center gap-2 w-full px-4 py-2.5 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"

--- a/routes/persons.php
+++ b/routes/persons.php
@@ -7,6 +7,7 @@ use App\Livewire\Declaration\DeclarationCreate;
 use App\Livewire\Declaration\DeclarationEdit;
 use App\Livewire\Declaration\DeclarationView;
 use App\Livewire\DiagnosticReport\DiagnosticReportCreate;
+use App\Livewire\DiagnosticReport\DiagnosticReportEdit;
 use App\Livewire\Encounter\EncounterCreate;
 use App\Livewire\Encounter\EncounterEdit;
 use App\Livewire\Person\PersonCreate;
@@ -96,6 +97,10 @@ Route::prefix('persons')->group(static function () {
         Route::get('{personId}/diagnostic-report/create', DiagnosticReportCreate::class)
             ->can('create', DiagnosticReport::class)
             ->name('diagnostic-report.create');
+
+        Route::get('{personId}/diagnostic-report/{diagnosticReportId}', DiagnosticReportEdit::class)
+            ->name('diagnostic-report.edit')
+            ->whereNumber('diagnosticReportId');
 
         Route::get('{personId}/procedure/create', ProcedureCreate::class)
             ->can('create', Procedure::class)


### PR DESCRIPTION
Close #278 

- Implemented diagnostic report edit page.
- Added route for opening an existing diagnostic report by UUID.
- Added loading of related observations for the diagnostic report.
- Added saving of updated diagnostic report data.