### PR TITLE
i278 Update diagnostic report validation

### DIFF
--- a/app/Livewire/DiagnosticReport/Forms/DiagnosticReportForm.php
+++ b/app/Livewire/DiagnosticReport/Forms/DiagnosticReportForm.php
@@ -5,18 +5,27 @@ declare(strict_types=1);
 namespace App\Livewire\DiagnosticReport\Forms;
 
 use App\Core\BaseForm;
+use App\Enums\User\Role;
 use App\Rules\AfterOrEqualDateTime;
 use App\Rules\InDictionary;
 use App\Rules\PastDateTime;
 use Carbon\CarbonImmutable;
 use Closure;
 use Illuminate\Validation\Rule;
+use Illuminate\Support\Facades\Auth;
 
 class DiagnosticReportForm extends BaseForm
 {
     public array $diagnosticReport = [];
 
     public array $observations = [];
+
+    private const LABORANT_ALLOWED_CATEGORIES = ['laboratory_procedure'];
+
+    private const RESULTS_INTERPRETER_REQUIRED_CATEGORIES = [
+        'diagnostic_procedure',
+        'imaging',
+    ];
 
     protected function rules(): array
     {
@@ -26,14 +35,34 @@ class DiagnosticReportForm extends BaseForm
             'diagnosticReport.categoryCode' => [
                 'required',
                 'string',
-                new InDictionary('eHealth/diagnostic_report_categories')
+                new InDictionary('eHealth/diagnostic_report_categories'),
+                function (string $attribute, mixed $value, Closure $fail): void {
+                    $employeeType = Auth::user()
+                        ?->getDiagnosticReportWriterEmployee()
+                        ?->employeeType;
+
+                    if (
+                        $employeeType === Role::LABORANT->value
+                        && !in_array($value, self::LABORANT_ALLOWED_CATEGORIES, true)
+                    ) {
+                        $fail(__('validation.custom.diagnosticReport.categoryCode.laborant_category'));
+                    }
+                },
             ],
             'diagnosticReport.codeValue' => [
                 'required',
                 'uuid',
             ],
             'diagnosticReport.paperReferralRequisition' => ['nullable', 'string', 'max:255'],
-            'diagnosticReport.paperReferralRequesterEmployeeName' => ['nullable', 'string', 'max:255'],
+            'diagnosticReport.paperReferralRequesterEmployeeName' => [
+                Rule::requiredIf(
+                    data_get($this->diagnosticReport, 'isReferralAvailable') === true
+                    && data_get($this->diagnosticReport, 'referralType') === 'paper'
+                ),
+                'nullable',
+                'string',
+                'max:255',
+            ],
             'diagnosticReport.paperReferralRequesterLegalEntityEdrpou' => [
                 Rule::requiredIf(
                     data_get($this->diagnosticReport, 'isReferralAvailable') === true
@@ -41,14 +70,8 @@ class DiagnosticReportForm extends BaseForm
                 ),
                 'nullable',
                 'digits_between:8,10',
-                'string',
-                'max:255',
             ],
             'diagnosticReport.paperReferralRequesterLegalEntityName' => [
-                Rule::requiredIf(
-                    data_get($this->diagnosticReport, 'isReferralAvailable') === true
-                    && data_get($this->diagnosticReport, 'referralType') === 'paper'
-                ),
                 'nullable',
                 'string',
                 'max:255',
@@ -59,7 +82,7 @@ class DiagnosticReportForm extends BaseForm
                     && data_get($this->diagnosticReport, 'referralType') === 'paper'
                 ),
                 'nullable',
-                'date',
+                'date_format:' . config('app.date_format'),
             ],
             'diagnosticReport.paperReferralNote' => ['nullable', 'string', 'max:255'],
             'diagnosticReport.effectivePeriodStartDate' => [
@@ -141,7 +164,17 @@ class DiagnosticReportForm extends BaseForm
                 'max:1000',
             ],
             'diagnosticReport.divisionId' => ['nullable', 'uuid'],
-            'diagnosticReport.resultsInterpreterEmployeeId' => ['nullable', 'uuid'],
+            'diagnosticReport.resultsInterpreterEmployeeId' => [
+                Rule::requiredIf(
+                    in_array(
+                        data_get($this->diagnosticReport, 'categoryCode'),
+                        self::RESULTS_INTERPRETER_REQUIRED_CATEGORIES,
+                        true
+                    )
+                ),
+                'nullable',
+                'uuid',
+            ],
 
             'observations' => ['nullable', 'array'],
             'observations.*.uuid' => ['nullable', 'uuid'],

--- a/resources/lang/uk/validation.php
+++ b/resources/lang/uk/validation.php
@@ -213,6 +213,11 @@ return [
                 'class_forbidden' => 'Тип взаємодії :value заборонений для вашого класу взаємодії'
             ]
         ],
+        'diagnosticReport' => [
+            'categoryCode' => [
+                'laborant_category' => 'Лаборант може створювати діагностичний звіт лише з категорією "Лабораторна процедура".',
+            ],
+        ],
         'conditions' => [
             'codeSystem' => [
                 'class_forbidden' => "Для класу взаємодії 'Амбулаторна медична допомога' та 'Стаціонарна медична допомога' дозволена лише система eHealth/ICD10_AM/condition_codes"

--- a/resources/views/livewire/encounter/diagnostic-report-parts/additional-information.blade.php
+++ b/resources/views/livewire/encounter/diagnostic-report-parts/additional-information.blade.php
@@ -107,6 +107,7 @@
                     id="resultsInterpreter"
                     class="input-select peer"
                     type="text"
+                    :required="['diagnostic_procedure', 'imaging'].includes(modalDiagnosticReport.categoryCode)"
             >
                 <option value="" selected>
                     {{ __('forms.select') }} {{ mb_strtolower(__('patients.the_doctor_who_interpreted_the_results')) }}

--- a/resources/views/livewire/encounter/diagnostic-report-parts/main-information.blade.php
+++ b/resources/views/livewire/encounter/diagnostic-report-parts/main-information.blade.php
@@ -138,9 +138,10 @@
                                            class="input peer"
                                            placeholder=" "
                                            autocomplete="off"
+                                           required
                                     >
                                     <label for="requesterEmployeeName" class="label">
-                                        {{ __('patients.author') }}
+                                        {{ __('patients.author') }} *
                                     </label>
 
                                     @error($diagnosticReportErrorPath . '.paperReferralRequesterEmployeeName')
@@ -178,7 +179,6 @@
                                            class="input peer"
                                            placeholder=" "
                                            autocomplete="off"
-                                           required
                                     >
                                     <label for="requesterLegalEntityName" class="label">
                                         {{ __('patients.name_of_the_institution_that_issued_it') }}


### PR DESCRIPTION
- Added validation for LABORANT users: they can create diagnostic reports only with the laboratory_procedure category.
- requester_employee_name, requester_legal_entity_edrpou, and service_request_date now are required;
- requisition, requester_legal_entity_name, and note remain optional.
- Added required validation for results_interpreter for diagnostic report categories that require it.
- Added Ukrainian validation message for LABORANT category restriction.