### PR TITLE
#316 diagnostic report view edit flow

### DIFF
--- a/app/Livewire/DiagnosticReport/DiagnosticReportComponent.php
+++ b/app/Livewire/DiagnosticReport/DiagnosticReportComponent.php
@@ -390,7 +390,7 @@ abstract class DiagnosticReportComponent extends Component
 
             Session::flash('success', __('patients.messages.diagnostic_report_create_request_sent'));
             $this->redirectRoute(
-                'diagnostic-report.edit',
+                'diagnostic-report.view',
                 [legalEntity(), 'personId' => $this->personId, 'diagnosticReportId' => $diagnosticReportId],
                 navigate: true
             );

--- a/app/Livewire/DiagnosticReport/DiagnosticReportEdit.php
+++ b/app/Livewire/DiagnosticReport/DiagnosticReportEdit.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\DiagnosticReport;
 
 use App\Core\Arr;
+use App\Enums\Person\DiagnosticReportStatus;
 use App\Models\LegalEntity;
 use App\Models\MedicalEvents\Sql\DiagnosticReport;
 use App\Repositories\MedicalEvents\Repository;
@@ -16,12 +17,16 @@ use Throwable;
 class DiagnosticReportEdit extends DiagnosticReportComponent
 {
     #[Locked]
-    public string $diagnosticReportId;
+    public int $diagnosticReportId;
 
-    public function mount(LegalEntity $legalEntity, int $personId, ?string $diagnosticReportId = null): void
+    public bool $isReadonly = false;
+
+    public function mount(LegalEntity $legalEntity, int $personId, ?int $diagnosticReportId = null): void
     {
         parent::mount($legalEntity, $personId);
+
         $this->diagnosticReportId = $diagnosticReportId;
+
         $diagnosticReport = DiagnosticReport::withAllRelations()
             ->whereKey($diagnosticReportId)
             ->where('person_id', $personId)
@@ -29,9 +34,14 @@ class DiagnosticReportEdit extends DiagnosticReportComponent
 
         $this->diagnosticReportUuid = $diagnosticReport->uuid;
 
+        $this->isReadonly = request()->routeIs('diagnostic-report.view')
+            || $diagnosticReport->status === DiagnosticReportStatus::FINAL;
+
         $diagnosticReportData = Fhir::diagnosticReport()->fromFhir(
             $diagnosticReport->toArray()
         );
+
+        $diagnosticReportData['status'] = $diagnosticReport->status->value;
 
         $conclusionCode = data_get($diagnosticReportData, 'conclusionCode');
 

--- a/app/Repositories/MedicalEvents/ObservationRepository.php
+++ b/app/Repositories/MedicalEvents/ObservationRepository.php
@@ -30,7 +30,7 @@ class ObservationRepository extends BaseRepository
         $this->employeeUuid = Auth::user()?->getDiagnosticReportWriterEmployee()?->uuid;
     }
 
-    public function getByDiagnosticReportId(string $diagnosticReportId): array
+    public function getByDiagnosticReportId(int $diagnosticReportId): array
     {
         $diagnosticReportUuid = DiagnosticReport::query()
             ->whereKey($diagnosticReportId)

--- a/resources/views/livewire/diagnostic-report/diagnostic-report.blade.php
+++ b/resources/views/livewire/diagnostic-report/diagnostic-report.blade.php
@@ -1,3 +1,7 @@
+@php
+    $isReadonly = $isReadonly ?? ($this->isReadonly ?? false);
+    $isDraft = data_get($this->form->diagnosticReport, 'status') === \App\Enums\Person\DiagnosticReportStatus::DRAFT->value;
+@endphp
 <section class="section-form">
     <x-header-navigation class="breadcrumb-form">
         <x-slot name="title">
@@ -26,32 +30,46 @@
         }"
     >
 
-        @include('livewire.encounter.diagnostic-report-parts.main-information', ['context' => 'diagnostic-report'])
-        @include('livewire.encounter.diagnostic-report-parts.additional-information', ['context' => 'diagnostic-report'])
-        @include('livewire.encounter.parts.observations')
+        <fieldset @disabled($isReadonly) @class(['pointer-events-none opacity-80' => $isReadonly])>
+            @include('livewire.encounter.diagnostic-report-parts.main-information', ['context' => 'diagnostic-report'])
+            @include('livewire.encounter.diagnostic-report-parts.additional-information', ['context' => 'diagnostic-report'])
+            @include('livewire.encounter.parts.observations')
+        </fieldset>
 
         <div class="flex gap-8">
             <a href="{{ url()->previous() }}" type="submit" class="button-minor">
                 {{ __('forms.back') }}
             </a>
 
-            <button @click.prevent="$wire.save(modalDiagnosticReport)" type="submit" class="button-primary-outline">
-                {{ __('forms.save') }}
-            </button>
+            @if($isReadonly && $isDraft)
+                <a href="{{ route('diagnostic-report.edit', [legalEntity(), 'personId' => $personId, 'diagnosticReportId' => $diagnosticReportId]) }}"
+                wire:navigate
+                class="button-primary"
+                >
+                    {{ __('forms.edit') }}
+                </a>
+            @endif
 
-            <button
-                @click="$wire.openSignatureModal(modalDiagnosticReport)"
-                type="button"
-                class="button-primary flex items-center gap-2"
-            >
-                @icon('key', 'w-5 h-5')
-                {{ __('forms.complete_the_interaction_and_sign') }}
-                @icon('arrow-right', 'w-5 h-5')
-            </button>
-        </div>
+            @unless($isReadonly)
+                <button @click.prevent="$wire.save(modalDiagnosticReport)" type="submit" class="button-primary-outline">
+                    {{ __('forms.save') }}
+                </button>
+
+                <button
+                    @click="$wire.openSignatureModal(modalDiagnosticReport)"
+                    type="button"
+                    class="button-primary flex items-center gap-2"
+                >
+                    @icon('key', 'w-5 h-5')
+                    {{ __('forms.complete_the_interaction_and_sign') }}
+                    @icon('arrow-right', 'w-5 h-5')
+                </button>
+            @endunless
     </form>
 
-    <x-signature-modal method="sign" />
+    @unless($isReadonly)
+        <x-signature-modal method="sign" />
+    @endunless
     <livewire:components.x-message :key="time()" />
     <x-forms.loading />
 </section>

--- a/resources/views/livewire/person/records/diagnostic-reports.blade.php
+++ b/resources/views/livewire/person/records/diagnostic-reports.blade.php
@@ -742,7 +742,7 @@
                                          class="absolute right-0 mt-2 w-56 rounded-md bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 shadow-lg z-50 py-1"
                                     >
                                         @if(!empty(data_get($diagnosticReport, 'id')))
-                                            <a  href="{{ route('diagnostic-report.edit', [legalEntity(), 'personId' => $personId, 'diagnosticReportId' => data_get($diagnosticReport, 'id')]) }}"
+                                            <a  href="{{ route('diagnostic-report.view', [legalEntity(), 'personId' => $personId, 'diagnosticReportId' => data_get($diagnosticReport, 'id')]) }}"
                                                 wire:navigate
                                                 class="flex items-center gap-2 w-full px-4 py-2.5 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
                                             >

--- a/routes/persons.php
+++ b/routes/persons.php
@@ -99,6 +99,10 @@ Route::prefix('persons')->group(static function () {
             ->name('diagnostic-report.create');
 
         Route::get('{personId}/diagnostic-report/{diagnosticReportId}', DiagnosticReportEdit::class)
+            ->name('diagnostic-report.view')
+            ->whereNumber('diagnosticReportId');
+
+        Route::get('{personId}/diagnostic-report/{diagnosticReportId}/edit', DiagnosticReportEdit::class)
             ->name('diagnostic-report.edit')
             ->whereNumber('diagnosticReportId');
 


### PR DESCRIPTION
Closes #316 

- Added a separate route for viewing Diagnostic Reports.
- Updated the Diagnostic Reports list so that the “View details” action opens the report in readonly mode.
- Added a separate edit route for draft Diagnostic Reports.
- Added an “Edit” button on the view page for draft reports.
- Final Diagnostic Reports are available only for viewing.
- Draft Diagnostic Reports can be viewed first and then edited from the view page.