### PR TITLE
#347: add new attributes to the divisions table

### DIFF
--- a/app/Classes/eHealth/Api/Division.php
+++ b/app/Classes/eHealth/Api/Division.php
@@ -389,6 +389,8 @@ class Division extends Request
             'phones.*.note' => 'sometimes|string',
             'status' => 'required|string',
             'type' => 'required|string',
+            'dls_id' => 'nullable|string',
+            'dls_verified' => 'nullable|boolean',
             'working_hours' => 'nullable|array',
             'working_hours.sun' => 'nullable|array',
             'working_hours.sun.*.0' => 'required|string',

--- a/app/Models/Division.php
+++ b/app/Models/Division.php
@@ -41,6 +41,8 @@ class Division extends Model
         'is_active',
         'legal_entity_id',
         'status',
+        'dls_id',
+        'dls_verified'
     ];
 
     protected $casts = [

--- a/database/migrations/install/2025_12_10_000022_create_divisions_table.php
+++ b/database/migrations/install/2025_12_10_000022_create_divisions_table.php
@@ -34,6 +34,8 @@ return new class extends Migration
             $table->boolean('is_active')->default(false);
             $table->foreignId('legal_entity_id')->constrained('legal_entities')->cascadeOnDelete()->cascadeOnUpdate();
             $table->enum('status', Status::only(self::VALID_STATUSES))->nullable();
+            $table->string('dls_id')->nullable();
+            $table->boolean('dls_verified')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/update/0_1/2026_06_19_193421_add_dls_attributes_to_divisions_table.php
+++ b/database/migrations/update/0_1/2026_06_19_193421_add_dls_attributes_to_divisions_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('divisions', function (Blueprint $table) {
+            if (!Schema::hasColumn('divisions', 'dls_id')) {
+                $table->string('dls_id')->nullable()->comment('DLS ID for the division');
+            }
+
+            if (!Schema::hasColumn('divisions', 'dls_verified')) {
+                $table->boolean('dls_verified')->nullable()->comment('Indicates whether the division has been verified by DLS');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('divisions', function (Blueprint $table) {
+            if (Schema::hasColumn('divisions', 'dls_id')) {
+                $table->dropColumn('dls_id');
+            }
+
+            if (Schema::hasColumn('divisions', 'dls_verified')) {
+                $table->dropColumn('dls_verified');
+            }
+        });
+    }
+};


### PR DESCRIPTION
This PR concerns the #347 ISSUE

Що було зроблено:
- додано два нових атрибути до таблиці divisions: `dls_id` і `dls_verified`;
- додано міграцію, яка додає ці атрибути в таблицю