### PR TITLE
#i29: fix confidant person sync

### DIFF
--- a/app/Classes/eHealth/Api/Person.php
+++ b/app/Classes/eHealth/Api/Person.php
@@ -436,7 +436,7 @@ class Person extends Request
 
         $validator = Validator::make($data, [
             '*.birth_country' => ['required', 'string', 'max:255'],
-            '*.birth_date' => ['required', 'date'],
+            '*.birth_date' => ['nullable', 'date'],
             '*.birth_settlement' => ['required', 'string', 'max:255'],
             '*.first_name' => ['required', 'string', 'max:255'],
             '*.gender' => ['required', new InDictionary('GENDER')],


### PR DESCRIPTION
This PR concerns the #29 ISSUE

Що було зроблено:
- в БД поле `birth_date` для Person позначене, як nullable, а у перевірці валідації - як `required`. Змінив у валідації як - nullable
