### PR TITLE
#356 fix(contracts): resolve contractor_owner_id fallback during eHealth sync

### DIFF
--- a/app/Repositories/ContractRepository.php
+++ b/app/Repositories/ContractRepository.php
@@ -30,7 +30,7 @@ class ContractRepository
         $attributes['contractor_owner_id'] = $eHealthData['contractor_owner']['id']
             ?? $eHealthData['contractor_owner']['uuid']
             ?? $eHealthData['contractor_owner_id']
-            ?? Employee::activeOwners(legalEntity()->id)->value('uuid');
+            ?? Employee::query()->activeOwners(legalEntity()->id)->value('uuid');
 
         return Contract::updateOrCreate(
             ['uuid' => $attributes['uuid']],

--- a/app/Repositories/ContractRequestRepository.php
+++ b/app/Repositories/ContractRequestRepository.php
@@ -6,6 +6,7 @@ namespace App\Repositories;
 
 use App\Classes\eHealth\Api\ContractRequest as ApiMapper;
 use App\Models\Contracts\ContractRequest;
+use App\Models\Employee\Employee;
 
 class ContractRequestRepository
 {
@@ -42,7 +43,8 @@ class ContractRequestRepository
         if (!isset($attributes['contractor_owner_id']) || empty($attributes['contractor_owner_id'])) {
             $attributes['contractor_owner_id'] = $eHealthData['contractor_owner_id']
                 ?? $eHealthData['contractor_owner']['id']
-                ?? legalEntity()->owner_id;
+                ?? $eHealthData['contractor_owner']['uuid']
+                ?? Employee::query()->activeOwners(legalEntity()->id)->value('uuid');
         }
 
         // 4. Handle JSON Data Column

--- a/tests/Feature/Contract/ContractRepositoryTest.php
+++ b/tests/Feature/Contract/ContractRepositoryTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Contract;
 
+use App\Enums\Status;
+use App\Enums\User\Role;
+use App\Models\Employee\Employee;
 use App\Models\LegalEntity;
+use App\Models\Relations\Party;
 use App\Repositories\ContractRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -156,6 +160,42 @@ class ContractRepositoryTest extends TestCase
         $contract = $this->repository->saveFromEHealth($eHealthData);
 
         $this->assertSame($programs, $contract->medical_programs);
+    }
+
+    public function test_save_from_ehealth_falls_back_to_active_owner_uuid(): void
+    {
+        $ownerUuid = (string) Str::uuid();
+        $this->createActiveOwner($ownerUuid);
+
+        $payload = $this->eHealthContractPayload();
+        unset($payload['contractor_owner'], $payload['contractor_owner_id']);
+
+        $contract = $this->repository->saveFromEHealth($payload);
+
+        $this->assertSame($ownerUuid, $contract->contractor_owner_id);
+    }
+
+    private function createActiveOwner(string $uuid): Employee
+    {
+        $party = Party::create([
+            'uuid' => (string) Str::uuid(),
+            'first_name' => 'Owner',
+            'last_name' => 'Test',
+            'tax_id' => '1234567890',
+            'birth_date' => '1970-01-01',
+            'gender' => 'MALE',
+        ]);
+
+        return Employee::create([
+            'uuid' => $uuid,
+            'employee_type' => Role::OWNER->value,
+            'status' => Status::APPROVED->value,
+            'legal_entity_id' => $this->legalEntity->id,
+            'is_active' => true,
+            'position' => 'Owner',
+            'start_date' => now()->format('Y-m-d'),
+            'party_id' => $party->id,
+        ]);
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Feature/Contract/ContractRequestRepositoryTest.php
+++ b/tests/Feature/Contract/ContractRequestRepositoryTest.php
@@ -6,7 +6,11 @@ namespace Tests\Feature\Contract;
 
 use App\Enums\Contract\Type;
 use App\Enums\JobStatus;
+use App\Enums\Status;
+use App\Enums\User\Role;
+use App\Models\Employee\Employee;
 use App\Models\LegalEntity;
+use App\Models\Relations\Party;
 use App\Repositories\ContractRequestRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -83,6 +87,54 @@ class ContractRequestRepositoryTest extends TestCase
     {
         $this->assertSame('REIMBURSEMENT', Type::REIMBURSEMENT->value);
         $this->assertSame('CAPITATION', Type::CAPITATION->value);
+    }
+
+    public function test_save_from_ehealth_falls_back_to_active_owner_uuid(): void
+    {
+        $ownerUuid = (string) Str::uuid();
+        $this->createActiveOwner($ownerUuid);
+
+        $payload = $this->eHealthContractRequestPayload();
+        unset($payload['contractor_owner_id']);
+
+        $contractRequest = $this->repository->saveFromEHealth($payload, 'REIMBURSEMENT');
+
+        $this->assertSame($ownerUuid, $contractRequest->contractor_owner_id);
+    }
+
+    public function test_save_from_ehealth_extracts_contractor_owner_uuid_from_nested_object(): void
+    {
+        $ownerUuid = (string) Str::uuid();
+        $payload = $this->eHealthContractRequestPayload();
+        unset($payload['contractor_owner_id']);
+        $payload['contractor_owner'] = ['uuid' => $ownerUuid];
+
+        $contractRequest = $this->repository->saveFromEHealth($payload, 'REIMBURSEMENT');
+
+        $this->assertSame($ownerUuid, $contractRequest->contractor_owner_id);
+    }
+
+    private function createActiveOwner(string $uuid): Employee
+    {
+        $party = Party::create([
+            'uuid' => (string) Str::uuid(),
+            'first_name' => 'Owner',
+            'last_name' => 'Test',
+            'tax_id' => '1234567890',
+            'birth_date' => '1970-01-01',
+            'gender' => 'MALE',
+        ]);
+
+        return Employee::create([
+            'uuid' => $uuid,
+            'employee_type' => Role::OWNER->value,
+            'status' => Status::APPROVED->value,
+            'legal_entity_id' => $this->legalEntity->id,
+            'is_active' => true,
+            'position' => 'Owner',
+            'start_date' => now()->format('Y-m-d'),
+            'party_id' => $party->id,
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Fix static call to `Employee::activeOwners()` in `ContractRepository` by using `Employee::query()->activeOwners()`.
- Replace invalid `legalEntity()->owner_id` fallback in `ContractRequestRepository` with the active owner scope and support `contractor_owner.uuid` from transformed eHealth payloads.
- Add repository tests covering owner UUID fallback when eHealth omits `contractor_owner`.

Closes #356

## Test plan

- [x] `vendor/bin/sail artisan test --compact tests/Feature/Contract/ContractRepositoryTest.php`
- [x] `vendor/bin/sail artisan test --compact tests/Feature/Contract/ContractRequestRepositoryTest.php`
- [ ] Manual sync on `/dashboard/{id}/contract-request` when eHealth list response has no `contractor_owner`
- [ ] Manual contract sync when eHealth omits `contractor_owner`