### PR TITLE
#271 add diagnostic report status colors

### DIFF
--- a/app/Enums/CarePlanStatus.php
+++ b/app/Enums/CarePlanStatus.php
@@ -32,4 +32,21 @@ enum CarePlanStatus: string
             self::UNKNOWN => __('forms.status.unknown'),
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::ACTIVE,
+            self::COMPLETED => 'badge-green',
+
+            self::PENDING,
+            self::ON_HOLD => 'badge-yellow',
+
+            self::REVOKED,
+            self::ENTERED_IN_ERROR => 'badge-red',
+
+            self::DRAFT,
+            self::UNKNOWN => 'badge-dark',
+        };
+    }
 }

--- a/app/Enums/Person/ClinicalImpressionStatus.php
+++ b/app/Enums/Person/ClinicalImpressionStatus.php
@@ -23,4 +23,12 @@ enum ClinicalImpressionStatus: string
             self::ENTERED_IN_ERROR => __('patients.status.entered_in_error')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::COMPLETED => 'badge-green',
+            self::ENTERED_IN_ERROR => 'badge-red',
+        };
+    }
 }

--- a/app/Enums/Person/ConditionClinicalStatus.php
+++ b/app/Enums/Person/ConditionClinicalStatus.php
@@ -29,4 +29,16 @@ enum ConditionClinicalStatus: string
             self::RESOLVED => __('patients.status.resolved')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::ACTIVE,
+            self::FINISHED,
+            self::RESOLVED => 'badge-green',
+
+            self::RECURRENCE,
+            self::REMISSION => 'badge-yellow',
+        };
+    }
 }

--- a/app/Enums/Person/ConditionVerificationStatus.php
+++ b/app/Enums/Person/ConditionVerificationStatus.php
@@ -29,4 +29,17 @@ enum ConditionVerificationStatus: string
             self::REFUTED => __('patients.status.refuted')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::CONFIRMED => 'badge-green',
+
+            self::DIFFERENTIAL,
+            self::PROVISIONAL => 'badge-yellow',
+
+            self::ENTERED_IN_ERROR,
+            self::REFUTED => 'badge-red',
+        };
+    }
 }

--- a/app/Enums/Person/ConfidantPersonRelationshipRequestStatus.php
+++ b/app/Enums/Person/ConfidantPersonRelationshipRequestStatus.php
@@ -29,4 +29,18 @@ enum ConfidantPersonRelationshipRequestStatus: string
             self::EXPIRED => __('patients.status.expired')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::APPROVED,
+            self::COMPLETED => 'badge-green',
+
+            self::NEW => 'badge-yellow',
+
+            self::CANCELLED => 'badge-red',
+
+            self::EXPIRED => 'badge-dark',
+        };
+    }
 }

--- a/app/Enums/Person/DiagnosticReportStatus.php
+++ b/app/Enums/Person/DiagnosticReportStatus.php
@@ -25,4 +25,13 @@ enum DiagnosticReportStatus: string
             self::DRAFT => __('patients.status.draft')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::FINAL => 'badge-green',
+            self::ENTERED_IN_ERROR => 'badge-red',
+            self::DRAFT => 'badge-dark',
+        };
+    }
 }

--- a/app/Enums/Person/EncounterStatus.php
+++ b/app/Enums/Person/EncounterStatus.php
@@ -23,4 +23,12 @@ enum EncounterStatus: string
             self::FINISHED => __('patients.status.completed')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::FINISHED => 'badge-green',
+            self::ENTERED_IN_ERROR => 'badge-red',
+        };
+    }
 }

--- a/app/Enums/Person/EpisodeStatus.php
+++ b/app/Enums/Person/EpisodeStatus.php
@@ -40,4 +40,16 @@ enum EpisodeStatus: string
             self::ENTERED_IN_ERROR => __('patients.status.entered_in_error')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::ACTIVE,
+            self::CLOSED => 'badge-green',
+
+            self::ENTERED_IN_ERROR => 'badge-red',
+
+            self::DRAFT => 'badge-dark',
+        };
+    }
 }

--- a/app/Enums/Person/ImmunizationStatus.php
+++ b/app/Enums/Person/ImmunizationStatus.php
@@ -23,4 +23,12 @@ enum ImmunizationStatus: string
             self::ENTERED_IN_ERROR => __('patients.status.entered_in_error')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::COMPLETED => 'badge-green',
+            self::ENTERED_IN_ERROR => 'badge-red',
+        };
+    }
 }

--- a/app/Enums/Person/ObservationStatus.php
+++ b/app/Enums/Person/ObservationStatus.php
@@ -23,4 +23,12 @@ enum ObservationStatus: string
             self::VALID => __('patients.status.valid')
         };
     }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::VALID => 'badge-green',
+            self::ENTERED_IN_ERROR => 'badge-red',
+        };
+    }
 }

--- a/app/Enums/Person/VerificationStatus.php
+++ b/app/Enums/Person/VerificationStatus.php
@@ -29,15 +29,18 @@ enum VerificationStatus: string
         };
     }
 
-    /**
-     * Gets the color class for UI badges.
-     */
     public function color(): string
     {
         return match ($this) {
-            self::CHANGES_NEEDED, self::IN_REVIEW, => 'badge-yellow',
-            self::NOT_VERIFIED, self::VERIFICATION_NEEDED => 'badge-red',
-            self::VERIFICATION_NOT_NEEDED, self::VERIFIED => 'badge-green'
+            self::VERIFIED => 'badge-green',
+
+            self::CHANGES_NEEDED,
+            self::IN_REVIEW,
+            self::VERIFICATION_NEEDED => 'badge-yellow',
+
+            self::NOT_VERIFIED => 'badge-red',
+
+            self::VERIFICATION_NOT_NEEDED => 'badge-dark',
         };
     }
 }

--- a/resources/views/livewire/person/parts/drawers/confidant-person-relationship-requests.blade.php
+++ b/resources/views/livewire/person/parts/drawers/confidant-person-relationship-requests.blade.php
@@ -25,8 +25,8 @@
             <tr>
                 <td class="td-input text-sm text-gray-600 dark:text-gray-400">{{ $request['uuid'] }}</td>
                 <td class="td-input">
-                        <span class="text-gray-700 dark:text-gray-300">
-                            {{ $request['status']->label() }}
+                        <span @class([$request['status']?->color()])>
+                            {{ $request['status']?->label() ?? '-' }}
                         </span>
                 </td>
                 <td class="td-input text-gray-700 dark:text-gray-300">

--- a/resources/views/livewire/person/records/care-plans.blade.php
+++ b/resources/views/livewire/person/records/care-plans.blade.php
@@ -238,9 +238,10 @@
                                 class="record-inner-column-bordered w-full md:w-36 shrink-0">
                                 <div class="record-inner-label">Статус:</div>
                                 <div>
-                                <span class="badge-green">
-                                    {{ $plan->status_display }}
-                                </span>
+                                    @php($status = CarePlanStatus::from(data_get($plan, 'status')))
+                                    <span @class([$status->color()])>
+                                        {{ $status->label() ?? '-' }}
+                                    </span>
                                 </div>
                             </div>
 

--- a/resources/views/livewire/person/records/clinical-impressions.blade.php
+++ b/resources/views/livewire/person/records/clinical-impressions.blade.php
@@ -194,8 +194,11 @@
                                 class="record-inner-column-bordered w-full md:w-36 shrink-0 h-full flex flex-col justify-center gap-1">
                                 <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                                 <div>
-                                    <span class="badge-green">
-                                        {{ ClinicalImpressionStatus::from(data_get($clinicalImpression, 'status'))->label() }}
+                                    @php
+                                        $status = ClinicalImpressionStatus::from(data_get($clinicalImpression, 'status'));
+                                    @endphp
+                                    <span @class([$status->color()])>
+                                        {{ $status->label() ?? '-' }}
                                     </span>
                                 </div>
                             </div>

--- a/resources/views/livewire/person/records/conditions.blade.php
+++ b/resources/views/livewire/person/records/conditions.blade.php
@@ -230,8 +230,9 @@
                             <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                                 <div class="record-inner-label">{{ __('patients.status_clinical') }}</div>
                                 <div>
-                                    <span class="badge-green">
-                                        {{ ConditionClinicalStatus::from(data_get($condition, 'clinicalStatus'))->label() }}
+                                    @php($status = ConditionClinicalStatus::from(data_get($condition, 'clinicalStatus')))
+                                    <span @class([$status->color()])>
+                                        {{ $status->label() ?? '-' }}
                                     </span>
                                 </div>
                             </div>
@@ -309,7 +310,10 @@
                                     <div class="min-w-0">
                                         <div class="record-inner-label">{{ __('patients.verification_status') }}</div>
                                         <div class="record-inner-value text-[14px] uppercase">
-                                            {{ ConditionVerificationStatus::from(data_get($condition, 'verificationStatus'))->label() }}
+                                            @php($verificationStatus = ConditionVerificationStatus::from(data_get($condition, 'verificationStatus')))
+                                            <span @class([$verificationStatus->color()])>
+                                                {{ $verificationStatus->label() ?? '-' }}
+                                            </span>
                                         </div>
                                     </div>
                                     <div class="min-w-0">

--- a/resources/views/livewire/person/records/diagnostic-reports.blade.php
+++ b/resources/views/livewire/person/records/diagnostic-reports.blade.php
@@ -698,8 +698,9 @@
                             <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                                 <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                                 <div>
-                                    <span class="badge-green">
-                                        {{ DiagnosticReportStatus::tryFrom(data_get($diagnosticReport, 'status'))?->label() ?? '-' }}
+                                    @php($status = DiagnosticReportStatus::from(data_get($diagnosticReport, 'status')))
+                                    <span @class([$status->color()])>
+                                        {{ $status->label() ?? '-' }}
                                     </span>
                                 </div>
                             </div>

--- a/resources/views/livewire/person/records/encounters.blade.php
+++ b/resources/views/livewire/person/records/encounters.blade.php
@@ -169,8 +169,9 @@
                             <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                                 <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                                 <div>
-                                    <span class="badge-green">
-                                        {{ EncounterStatus::from(data_get($encounter, 'status'))->label() }}
+                                    @php($status = EncounterStatus::from(data_get($encounter, 'status')))
+                                    <span @class([$status->color()])>
+                                        {{ $status->label() }}
                                     </span>
                                 </div>
                             </div>

--- a/resources/views/livewire/person/records/immunization.blade.php
+++ b/resources/views/livewire/person/records/immunization.blade.php
@@ -178,8 +178,9 @@
                                 </div>
 
                                 <div>
-                                    <span class="badge-green">
-                                        {{ ImmunizationStatus::from(data_get($immunization, 'status'))->label() }}
+                                    @php($status = ImmunizationStatus::from(data_get($immunization, 'status')))
+                                    <span @class([$status->color()])>
+                                        {{ $status->label() }}
                                     </span>
                                 </div>
                             </div>

--- a/resources/views/livewire/person/records/observations.blade.php
+++ b/resources/views/livewire/person/records/observations.blade.php
@@ -231,8 +231,9 @@
                             <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                                 <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                                 <div>
-                                    <span class="badge-green">
-                                        {{ ObservationStatus::from($observation['status'])->label() }}
+                                    @php($status = ObservationStatus::from(data_get($observation, 'status')))
+                                    <span @class([$status->color()])>
+                                        {{ $status->label() }}
                                     </span>
                                 </div>
                             </div>

--- a/resources/views/livewire/person/records/parts/clinical-impressions.blade.php
+++ b/resources/views/livewire/person/records/parts/clinical-impressions.blade.php
@@ -24,8 +24,9 @@
                     class="record-inner-column-bordered w-full md:w-36 shrink-0 h-full flex flex-col justify-center gap-1">
                     <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                     <div>
-                        <span class="badge-green">
-                            {{ ClinicalImpressionStatus::from(data_get($clinicalImpression, 'status'))->label() }}
+                        @php($status = ClinicalImpressionStatus::from(data_get($clinicalImpression, 'status')))
+                        <span @class([$status->color()])>
+                            {{ $status->label() }}
                         </span>
                     </div>
                 </div>

--- a/resources/views/livewire/person/records/parts/conditions.blade.php
+++ b/resources/views/livewire/person/records/parts/conditions.blade.php
@@ -32,8 +32,9 @@
                 <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                     <div class="record-inner-label">{{ __('patients.status_clinical') }}</div>
                     <div>
-                        <span class="badge-green">
-                            {{ ConditionClinicalStatus::from(data_get($condition, 'clinicalStatus'))->label() }}
+                        @php($status = ConditionClinicalStatus::from(data_get($condition, 'clinicalStatus')))
+                        <span @class([$status->color()])>
+                            {{ $status->label() ?? '-' }}
                         </span>
                     </div>
                 </div>
@@ -58,7 +59,10 @@
                         <div>
                             <div class="record-inner-label">{{ __('patients.verification_status') }}</div>
                             <div class="record-inner-subvalue">
-                                {{ ConditionClinicalStatus::from(data_get($condition, 'clinicalStatus'))->label() }}
+                                @php($verificationStatus = ConditionVerificationStatus::from(data_get($condition, 'verificationStatus')))
+                                <span @class([$verificationStatus->color()])>
+                                    {{ $verificationStatus->label() ?? '-' }}
+                                </span>
                             </div>
                         </div>
                         <div>

--- a/resources/views/livewire/person/records/parts/diagnostic-reports.blade.php
+++ b/resources/views/livewire/person/records/parts/diagnostic-reports.blade.php
@@ -21,8 +21,9 @@
                 <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                     <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                     <div>
-                        <span class="badge-yellow">
-                             {{ DiagnosticReportStatus::from(data_get($diagnosticReport, 'status'))->label() }}
+                        @php($status = DiagnosticReportStatus::from(data_get($diagnosticReport, 'status')))
+                        <span @class([$status->color()])>
+                             {{ $status->label() }}
                         </span>
                     </div>
                 </div>

--- a/resources/views/livewire/person/records/parts/encounters.blade.php
+++ b/resources/views/livewire/person/records/parts/encounters.blade.php
@@ -23,8 +23,9 @@
                 <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                     <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                     <div>
-                        <span class="badge-green">
-                            {{ EncounterStatus::from(data_get($encounter, 'status'))->label() }}
+                        @php($status = EncounterStatus::from(data_get($encounter, 'status')))
+                        <span @class([$status->color()])>
+                            {{ $status->label() }}
                         </span>
                     </div>
                 </div>

--- a/resources/views/livewire/person/records/parts/episodes.blade.php
+++ b/resources/views/livewire/person/records/parts/episodes.blade.php
@@ -22,8 +22,9 @@
                 <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                     <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                     <div>
-                        <span class="badge-green">
-                            {{ EpisodeStatus::from(data_get($episode, 'status'))->label() }}
+                        @php($status = EpisodeStatus::from(data_get($episode, 'status')))
+                        <span @class([$status->color()])>
+                            {{ $status->label() }}
                         </span>
                     </div>
                 </div>

--- a/resources/views/livewire/person/records/parts/immunizations.blade.php
+++ b/resources/views/livewire/person/records/parts/immunizations.blade.php
@@ -23,8 +23,9 @@
                 <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                     <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                     <div>
-                        <span class="badge-green">
-                            {{ ImmunizationStatus::from($immunization['status'])->label() }}
+                        @php($status = ImmunizationStatus::from(data_get($immunization, 'status')))
+                        <span @class([$status->color()])>
+                            {{ $status->label() }}
                         </span>
                     </div>
                 </div>

--- a/resources/views/livewire/person/records/parts/observations.blade.php
+++ b/resources/views/livewire/person/records/parts/observations.blade.php
@@ -33,8 +33,9 @@
                 <div class="record-inner-column-bordered w-full md:w-36 shrink-0">
                     <div class="record-inner-label">{{ __('forms.status.label') }}</div>
                     <div>
-                        <span class="badge-green">
-                            {{ ObservationStatus::from(data_get($observation, 'status'))->label() }}
+                        @php($status = ObservationStatus::from(data_get($observation, 'status')))
+                        <span @class([$status->color()])>
+                            {{ $status->label() }}
                         </span>
                     </div>
                 </div>

--- a/resources/views/livewire/person/records/patient-data.blade.php
+++ b/resources/views/livewire/person/records/patient-data.blade.php
@@ -5,7 +5,11 @@
     <div class="breadcrumb-form p-4 shift-content">
         <div class="flex items-center gap-14 mb-10">
             <p class="default-p">
-                {{ __('patients.verification_in_eHealth') }}: {{ Status::from($verificationStatus)->label() }}
+                @php($status = Status::from($verificationStatus))
+                {{ __('patients.verification_in_eHealth') }}:
+                <span @class([$status->color()])>
+                    {{ $status->label() ?? '-' }}
+                </span>
             </p>
 
             <div>


### PR DESCRIPTION
Closes #271 

- Added a shared StatusColor trait for patient record status enums.
- Applied status color handling to care plans, clinical impressions, conditions, diagnostic reports, encounters, episodes, immunizations, observations, patient verification, and confidant person relationship requests.
- Replaced hardcoded badge classes in patient record views with enum-based status color methods.