### PR TITLE
#367 Fix Care Plan clinical protocol and local field persistence

### DIFF
--- a/app/Livewire/CarePlan/CarePlanCreate.php
+++ b/app/Livewire/CarePlan/CarePlanCreate.php
@@ -445,6 +445,7 @@ class CarePlanCreate extends BasePatientComponent
             'description' => $this->form->description ?: null,
             'note' => $this->form->note ?: null,
             'inform_with' => $this->form->informWith ?: null,
+            'terms_of_service' => $this->form->termsOfService ?: null,
         ]);
 
         session()->flash('success', __('care-plan.draft_saved') ?? 'План лікування успішно збережено');
@@ -682,6 +683,17 @@ class CarePlanCreate extends BasePatientComponent
                 'period_start' => convertToYmd($this->form->periodStart),
                 'period_end' => !empty($this->form->periodEnd) ? convertToYmd($this->form->periodEnd) : null,
                 'encounter_id' => $encounterData['id'] ?? null,
+                'clinical_protocol' => $this->form->clinicalProtocol ?: null,
+                'context' => $this->form->context ?: null,
+                'terms_of_service' => $this->form->termsOfService ?: null,
+                'description' => $this->form->description ?: null,
+                'note' => $this->form->note ?: null,
+                'inform_with' => $this->form->informWith ?: null,
+                'addresses' => $encounterData['addresses'],
+                'supporting_info' => [
+                    'episodes' => $this->form->episodes,
+                    'medical_records' => $this->form->medicalRecords,
+                ],
             ]);
 
             $this->showSignatureModal = false;

--- a/app/Livewire/CarePlan/CarePlanShow.php
+++ b/app/Livewire/CarePlan/CarePlanShow.php
@@ -694,7 +694,6 @@ class CarePlanShow extends Component
                     ]
                 ]
             ],
-            'instantiates_protocol' => $this->carePlan->clinical_protocol ? [['display' => $this->carePlan->clinical_protocol]] : null,
             'title' => $this->carePlan->title,
             'period' => $period,
             'addresses' => !empty($addresses) ? $addresses : null,
@@ -818,7 +817,6 @@ class CarePlanShow extends Component
             'intent' => 'order',
             'status' => CarePlanStatus::DRAFT->value,
             'category' => is_array($this->carePlan->category) ? ($this->carePlan->category['coding'][0]['code'] ?? null) : $this->carePlan->category,
-            'instantiates_protocol' => $this->carePlan->clinical_protocol ? [['display' => $this->carePlan->clinical_protocol]] : null,
             'context' => $this->carePlan->context ? ['identifier' => ['type_code' => $this->carePlan->context]] : null,
             'title' => $this->carePlan->title,
             'period' => array_filter([

--- a/app/Livewire/CarePlan/CarePlanUpdate.php
+++ b/app/Livewire/CarePlan/CarePlanUpdate.php
@@ -144,6 +144,7 @@ class CarePlanUpdate extends CarePlanCreate
             'description' => $this->form->description ?: null,
             'note' => $this->form->note ?: null,
             'inform_with' => $this->form->informWith ?: null,
+            'terms_of_service' => $this->form->termsOfService ?: null,
         ]);
 
         session()->flash('success', __('care-plan.draft_updated') ?? 'План лікування успішно збережено');
@@ -281,6 +282,12 @@ class CarePlanUpdate extends CarePlanCreate
                     'episodes' => $this->form->episodes,
                     'medical_records' => $this->form->medicalRecords,
                 ],
+                'clinical_protocol' => $this->form->clinicalProtocol ?: null,
+                'context' => $this->form->context ?: null,
+                'terms_of_service' => $this->form->termsOfService ?: null,
+                'description' => $this->form->description ?: null,
+                'note' => $this->form->note ?: null,
+                'inform_with' => $this->form->informWith ?: null,
             ]);
 
             session()->flash('success', __('care-plan.signed_and_sent'));

--- a/app/Repositories/CarePlanRepository.php
+++ b/app/Repositories/CarePlanRepository.php
@@ -115,7 +115,6 @@ class CarePlanRepository
                     ['system' => 'eHealth/care_plan_categories', 'code' => $form['category']]
                 ]
             ],
-            'instantiates_protocol' => !empty($form['clinicalProtocol']) ? [['display' => $form['clinicalProtocol']]] : (!empty($form['clinical_protocol']) ? [['display' => $form['clinical_protocol']]] : null),
             'title' => $form['title'],
             'period' => array_filter([
                 'start' => $finalPeriodStart,
@@ -144,7 +143,8 @@ class CarePlanRepository
                 'coding' => [
                     ['system' => 'PROVIDING_CONDITION', 'code' => $form['termsOfService'] ?? $form['terms_of_service']]
                 ]
-            ]
+            ],
+            'inform_with' => $form['informWith'] ?? ($form['inform_with'] ?? null)
         ]);
 
         return $payload;

--- a/tests/Feature/CarePlan/CarePlanLifecycleTest.php
+++ b/tests/Feature/CarePlan/CarePlanLifecycleTest.php
@@ -569,5 +569,168 @@ class CarePlanLifecycleTest extends TestCase
             'status' => 'cancelled',
         ]);
     }
+
+    public function test_local_persistence_and_payload_formatting_without_instantiates_protocol(): void
+    {
+        $this->actingAs($this->user);
+        $carePlanUuid = (string) Str::uuid();
+
+        $mockCarePlanApi = Mockery::mock(\App\Classes\eHealth\Api\CarePlan::class);
+        $mockApprovalApi = Mockery::mock(\App\Classes\eHealth\Api\Approval::class);
+        $mockPatientApi = Mockery::mock(\App\Classes\eHealth\Api\Person::class);
+        $mockJobApi = Mockery::mock(\App\Classes\eHealth\Api\Job::class);
+        $mockSignatureService = Mockery::mock(\App\Services\SignatureService::class);
+
+        $this->instance(\App\Classes\eHealth\Api\CarePlan::class, $mockCarePlanApi);
+        $this->instance(\App\Classes\eHealth\Api\Approval::class, $mockApprovalApi);
+        $this->instance(\App\Classes\eHealth\Api\Person::class, $mockPatientApi);
+        $this->instance(\App\Classes\eHealth\Api\Job::class, $mockJobApi);
+        $this->instance(\App\Services\SignatureService::class, $mockSignatureService);
+
+        $capturedPayload = null;
+        $mockSignatureService->shouldReceive('signData')
+            ->andReturnUsing(function ($payload) use (&$capturedPayload) {
+                $capturedPayload = $payload;
+                return 'mock-base64-signature';
+            });
+        $mockSignatureService->shouldReceive('getCertificateAuthorities')->andReturn([]);
+
+        $cpCreateResponse = Mockery::mock(\App\Classes\eHealth\EHealthResponse::class);
+        $cpCreateResponse->shouldReceive('getData')->andReturn(['job_id' => 'job-123']);
+        $cpCreateResponse->shouldReceive('getStatusCode')->andReturn(202);
+        $mockCarePlanApi->shouldReceive('create')->andReturn($cpCreateResponse);
+
+        $jobResponse = Mockery::mock(\App\Classes\eHealth\EHealthResponse::class);
+        $jobResponse->shouldReceive('getData')->andReturn([
+            'status' => 'processed',
+            'id' => $carePlanUuid,
+            'result' => [
+                'id' => $carePlanUuid,
+                'status' => 'active'
+            ]
+        ]);
+        $mockJobApi->shouldReceive('getDetails')->andReturn($jobResponse);
+
+        $authResponse = Mockery::mock(\App\Classes\eHealth\EHealthResponse::class);
+        $authResponse->shouldReceive('getData')->andReturn([]);
+        $authResponse->shouldReceive('getStatusCode')->andReturn(200);
+        $mockPatientApi->shouldReceive('getAuthMethods')->andReturn($authResponse);
+
+        // 1. Test Save Draft on Create Component
+        Livewire::test(\App\Livewire\CarePlan\CarePlanCreate::class, [
+            'legalEntity' => \App\Models\LegalEntity::first(),
+            'personId' => $this->person->id,
+        ])
+            ->set('form.encounter', $this->encounter->uuid)
+            ->set('form.title', 'Draft Plan')
+            ->set('form.category', '736382003')
+            ->set('form.clinicalProtocol', 'Protocol-123')
+            ->set('form.context', 'context-value')
+            ->set('form.termsOfService', 'PROVIDING_CONDITION')
+            ->set('form.description', 'My Description')
+            ->set('form.note', 'My Note')
+            ->set('form.informWith', 'SMS')
+            ->set('form.periodStart', now()->format('d.m.Y'))
+            ->call('save')
+            ->assertHasNoErrors();
+
+        // Check local draft is persisted with terms_of_service and clinical_protocol
+        $this->assertDatabaseHas('care_plans', [
+            'title' => 'Draft Plan',
+            'status' => 'draft',
+            'clinical_protocol' => 'Protocol-123',
+            'context' => 'context-value',
+            'terms_of_service' => 'PROVIDING_CONDITION',
+            'description' => 'My Description',
+            'note' => 'My Note',
+            'inform_with' => 'SMS',
+        ]);
+
+        $draft = CarePlan::where('title', 'Draft Plan')->firstOrFail();
+
+        // 2. Test Sign on Create Component
+        Livewire::test(\App\Livewire\CarePlan\CarePlanCreate::class, [
+            'legalEntity' => \App\Models\LegalEntity::first(),
+            'personId' => $this->person->id,
+        ])
+            ->set('form.encounter', $this->encounter->uuid)
+            ->set('form.title', 'Signed Plan')
+            ->set('form.category', '736382003')
+            ->set('form.clinicalProtocol', 'Protocol-123')
+            ->set('form.context', 'context-value')
+            ->set('form.termsOfService', 'PROVIDING_CONDITION')
+            ->set('form.description', 'My Description')
+            ->set('form.note', 'My Note')
+            ->set('form.informWith', 'SMS')
+            ->set('form.periodStart', now()->format('d.m.Y'))
+            ->set('form.knedp', '1.2.3.4')
+            ->set('form.password', 'secret')
+            ->set('form.keyContainerUpload', \Illuminate\Http\UploadedFile::fake()->create('key.jks', 100))
+            ->call('sign')
+            ->assertHasNoErrors();
+
+        // Check payload did NOT contain instantiates_protocol, but did contain inform_with
+        $this->assertNotNull($capturedPayload);
+        $this->assertFalse(array_key_exists('instantiates_protocol', $capturedPayload));
+        $this->assertFalse(array_key_exists('instantiates_protocol', Arr::toSnakeCase($capturedPayload)));
+        $this->assertEquals('SMS', $capturedPayload['inform_with'] ?? null);
+
+        // Check signed Care Plan is in DB with all fields persisted locally
+        $this->assertDatabaseHas('care_plans', [
+            'uuid' => $carePlanUuid,
+            'status' => 'active',
+            'clinical_protocol' => 'Protocol-123',
+            'context' => 'context-value',
+            'terms_of_service' => 'PROVIDING_CONDITION',
+            'description' => 'My Description',
+            'note' => 'My Note',
+            'inform_with' => 'SMS',
+        ]);
+
+        // 3. Test Save Draft on Update Component
+        Livewire::test(\App\Livewire\CarePlan\CarePlanUpdate::class, [
+            'legalEntity' => \App\Models\LegalEntity::first(),
+            'carePlan' => $draft,
+        ])
+            ->set('form.title', 'Updated Draft Plan')
+            ->set('form.termsOfService', 'PROVIDING_CONDITION_NEW')
+            ->set('form.clinicalProtocol', 'Protocol-New')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('care_plans', [
+            'id' => $draft->id,
+            'title' => 'Updated Draft Plan',
+            'terms_of_service' => 'PROVIDING_CONDITION_NEW',
+            'clinical_protocol' => 'Protocol-New',
+        ]);
+
+        // 4. Test Sign on Update Component
+        $capturedPayload = null;
+        Livewire::test(\App\Livewire\CarePlan\CarePlanUpdate::class, [
+            'legalEntity' => \App\Models\LegalEntity::first(),
+            'carePlan' => $draft,
+        ])
+            ->set('form.title', 'Signed Updated Plan')
+            ->set('form.termsOfService', 'PROVIDING_CONDITION_SIGNED')
+            ->set('form.clinicalProtocol', 'Protocol-Signed')
+            ->set('form.knedp', '1.2.3.4')
+            ->set('form.password', 'secret')
+            ->set('form.keyContainerUpload', \Illuminate\Http\UploadedFile::fake()->create('key.jks', 100))
+            ->call('sign')
+            ->assertHasNoErrors();
+
+        // Check payload did NOT contain instantiates_protocol
+        $this->assertNotNull($capturedPayload);
+        $this->assertFalse(array_key_exists('instantiates_protocol', $capturedPayload));
+
+        // Check updated Care Plan is in DB with all fields updated locally
+        $this->assertDatabaseHas('care_plans', [
+            'id' => $draft->id,
+            'title' => 'Signed Updated Plan',
+            'terms_of_service' => 'PROVIDING_CONDITION_SIGNED',
+            'clinical_protocol' => 'Protocol-Signed',
+        ]);
+    }
 }
 


### PR DESCRIPTION
Resolves #367. Excludes instantiates_protocol from eHealth payloads and adds missing local persistence fields on Care Plan draft save and sign.