### PR TITLE
#190: fix declaration sync issues

### DIFF
--- a/app/Classes/eHealth/Api/Person.php
+++ b/app/Classes/eHealth/Api/Person.php
@@ -471,6 +471,15 @@ class Person extends Request
 
         $replaced = self::replaceEHealthPropNames($data);
 
+        // Save alias for third person auth method if it is not set
+        $replaced = Arr::map($replaced, function ($item) {
+            if (isset($item['type']) && $item['type'] === AuthenticationMethod::THIRD_PERSON->value && !isset($item['alias'])) {
+                $item['alias'] = __('UNKNOWN');
+            }
+
+            return $item;
+        });
+
         $validator = Validator::make($replaced, [
             '*.uuid' => ['required', 'uuid'],
             '*.type' => ['required', 'string', Rule::in(AuthenticationMethod::values())],

--- a/app/Core/EHealthJob.php
+++ b/app/Core/EHealthJob.php
@@ -6,6 +6,7 @@ namespace App\Core;
 
 use Throwable;
 use App\Models\User;
+use ReflectionClass;
 use App\Enums\JobStatus;
 use Illuminate\Bus\Batch;
 use App\Traits\FormTrait;
@@ -194,13 +195,22 @@ abstract class EHealthJob implements ShouldQueue
         if ($this->user) {
             $this->token = $this->getToken();
 
-            // Prepare the current job for retry
-            $retryJob = new static(
-                legalEntity: $this->legalEntity,
-                page: $this->page,
-                isFirstLogin: $this->isFirstLogin,
-                nextEntity: $this->nextEntity
-            );
+            $reflection = new ReflectionClass(static::class);
+
+            $args = [];
+
+            // Use reflection to get the constructor parameters of the current job class
+            // This need due to some of job's params doesn't exist in all job classes,
+            // so we need to dynamically determine which parameters to pass when creating a new instance of the job for retry
+            foreach ($reflection->getConstructor()?->getParameters() ?? [] as $param) {
+                $name = $param->getName();
+
+                if (property_exists($this, $name)) {
+                    $args[$name] = $this->{$name};
+                }
+            }
+
+            $retryJob = new static(...$args);
 
             $failedJobUuids = $this->batch()?->failedJobIds ?? [];
             $failedBatchId = $this->batch()?->id;
@@ -319,7 +329,7 @@ abstract class EHealthJob implements ShouldQueue
 
         // Execute complex query to find users matching three criteria
         $users = User::with('roles', 'permissions')
-            // FIRST CRITERIA: Exclude current user's party from search (if it still logined but does not have valid token)
+            // FIRST CRITERIA: Exclude current user's party from search (if it still logined but if here (error occurs), we need to find another user)
             ->whereNot('users.party_id', $user->party_id ?? 0)
             // SECOND CRITERIA: User must be employee of this legal entity
             // This uses nested whereHas to check User -> Employee relationship

--- a/app/Jobs/ConfidantPersonSync.php
+++ b/app/Jobs/ConfidantPersonSync.php
@@ -110,10 +110,10 @@ class ConfidantPersonSync extends EHealthJob
     protected function getPersonSearchData(): array
     {
         return [
-            'first_name' => $this->person->first_name,
-            'last_name' => $this->person->last_name,
-            'birth_date' => convertToYmd($this->person->birth_date),
-            'tax_id' => $this->person->tax_id ?? null,
+            'first_name' => $this->person->firstName,
+            'last_name' => $this->person->lastName,
+            'birth_date' => convertToYmd($this->person->birthDate),
+            'tax_id' => $this->person->taxId ?? null,
             'phone_number' => $this->person->phones->first()?->number ?? null,
         ];
     }
@@ -129,10 +129,10 @@ class ConfidantPersonSync extends EHealthJob
      */
     protected function checkPersonData(array $data): bool
     {
-        return $data['first_name'] === $this->person->first_name
-            && $data['last_name'] === $this->person->last_name
-            && $data['birth_date'] === convertToYmd($this->person->birth_date)
-            && ($this->person->tax_id === null || $data['tax_id'] === $this->person->tax_id);
+        return $data['first_name'] === $this->person->firstName
+            && $data['last_name'] === $this->person->lastName
+            && $data['birth_date'] === convertToYmd($this->person->birthDate)
+            && ($this->person->taxId === null || $data['tax_id'] === $this->person->taxId);
     }
 
     /**

--- a/app/Jobs/DeclarationDetailsSync.php
+++ b/app/Jobs/DeclarationDetailsSync.php
@@ -128,6 +128,8 @@ class DeclarationDetailsSync extends EHealthJob
 
         if (!empty($validatedData)) {
             $this->declaration->update($validatedData);
+
+            $this->declaration->refresh();
         }
 
         if ($this->legalEntity->status === Status::REORGANIZED->value) {
@@ -150,9 +152,16 @@ class DeclarationDetailsSync extends EHealthJob
     // Get next entity job if needed
     protected function getNextEntityJob(): ?EHealthJob
     {
-        return $this->standalone || !$this->nextEntity
+        // After declaration's details sync, we need to sync the person's authentication methods if they exist
+        $personAuthMethodJob = $this->declaration?->person
+            ? new PersonAuthMethodSync($this->declaration->person, $this->legalEntity, $this->nextEntity)
+            : null;
+
+        $nextEntity = $personAuthMethodJob ?? $this->nextEntity;
+
+        return $this->standalone || !$nextEntity
             ? new CompleteSync($this->legalEntity, isFirstLogin: $this->isFirstLogin)
-            : $this->getConfidantPersonStartJob($this->legalEntity, $this->nextEntity);
+            : $nextEntity;
     }
 
     /**

--- a/app/Jobs/DeclarationRequestDetailsSync.php
+++ b/app/Jobs/DeclarationRequestDetailsSync.php
@@ -127,7 +127,7 @@ class DeclarationRequestDetailsSync extends EHealthJob
                 echo "Confidant Person for this person has been synced: " . PHP_EOL;
             }
         }
-    
+
         $validatedData['sync_status'] = JobStatus::COMPLETED->value;
 
         $this->declarationRequest->update($validatedData);
@@ -141,7 +141,7 @@ class DeclarationRequestDetailsSync extends EHealthJob
     protected function getAdditionalMiddleware(): array
     {
         return [
-            new RateLimited('ehealth-declaration-get')
+            new RateLimited('ehealth-declaration-request-get')
         ];
     }
 

--- a/app/Jobs/PersonAuthMethodSync.php
+++ b/app/Jobs/PersonAuthMethodSync.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Core\EHealthJob;
+use App\Models\LegalEntity;
+use App\Models\Person\Person;
+use App\Classes\eHealth\EHealth;
+use App\Repositories\Repository;
+use GuzzleHttp\Promise\PromiseInterface;
+use App\Classes\eHealth\EHealthResponse;
+use Illuminate\Queue\Middleware\RateLimited;
+
+class PersonAuthMethodSync extends EHealthJob
+{
+    public const string BATCH_NAME = 'PersonAuthMethodSync';
+
+    public const string SCOPE_REQUIRED = 'person:read';
+
+    public const string ENTITY = LegalEntity::ENTITY_DECLARATION;
+
+    public function __construct(
+        public Person $person,
+        public ?LegalEntity $legalEntity,
+        protected ?EHealthJob $nextEntity = null,
+        public bool $standalone = false,
+    ) {
+        parent::__construct(legalEntity: $legalEntity, nextEntity: $nextEntity, standalone: $standalone);
+    }
+
+    /**
+     * Get declarations data from EHealth API
+     *
+     * @param  string  $token
+     * @return PromiseInterface|EHealthResponse
+     */
+    protected function sendRequest(string $token): PromiseInterface|EHealthResponse|null
+    {
+        try {
+            $response = EHealth::person()->withToken($token)->getAuthMethods($this->person->uuid);
+        } catch (\Throwable $e) {
+            \Log::warning("PersonAuthMethodSync: Failed to get authentication methods for person " . $this->person->uuid . ". Error: " . $e->getMessage() . " Code: " . $e->getCode());
+
+            // In some cases person is present in our database but not in EHealth, so we need to handle 404 error gracefully
+            if ($e->getCode() === 404) {
+                return null;
+            }
+
+            throw $e;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Store or update all the declarations data in the database
+     *
+     * @param  EHealthResponse|null  $response
+     * @throws \Throwable
+     */
+    protected function processResponse(?EHealthResponse $response): void
+    {
+        if (\is_null($response)) {
+           return;
+        }
+
+        $authMethods = $response->validate();
+
+        Repository::authenticationMethod()->sync($this->person, $authMethods);
+    }
+
+    /**
+     * Get additional middleware configurations for the job.
+     *
+     * @return array Returns an array of middleware configurations to be applied to the job
+     */
+    protected function getAdditionalMiddleware(): array
+    {
+        return [
+            new RateLimited('person-authentication-method-get')
+        ];
+    }
+
+    /**
+     * Get the next entity job to be scheduled after PersonAuthMethodSync completes.
+     *
+     * If the job is standalone, returns a CompleteSync job for the current legal entity.
+     * Otherwise, returns the next entity job in the chain.
+     *
+     * @return EHealthJob|null
+     */
+    protected function getNextEntityJob(): ?EHealthJob
+    {
+        $nextEntity = $this->getConfidantPersonStartJob($this->legalEntity, $this->nextEntity) ?? $this->nextEntity;
+
+        return $this->standalone || !$nextEntity
+            ? new CompleteSync($this->legalEntity, isFirstLogin: $this->isFirstLogin)
+            : $nextEntity;
+    }
+}

--- a/app/Policies/DeclarationPolicy.php
+++ b/app/Policies/DeclarationPolicy.php
@@ -25,7 +25,7 @@ class DeclarationPolicy
         $legalEntity = legalEntity();
 
         if (
-            $legalEntity->status !== LegalEntityStatus::ACTIVE->value
+            ($legalEntity->status !== LegalEntityStatus::ACTIVE->value && $legalEntity->status !== LegalEntityStatus::REORGANIZED->value)
             || !in_array($legalEntity->type->name, config('ehealth.declaration_request_legal_entity_types'), true)
         ) {
             return Response::denyWithStatus(404);
@@ -55,7 +55,7 @@ class DeclarationPolicy
             return Response::denyWithStatus(404);
         }
 
-        if ($user->hasAllowedRole(Role::OWNER) && $declaration->legalEntityId === legalEntity()->id) {
+        if ($user->hasAllowedRole([Role::OWNER, Role::REORGANIZATION_OWNER]) && $declaration->legalEntityId === legalEntity()->id) {
             return Response::allow();
         }
 
@@ -86,10 +86,10 @@ class DeclarationPolicy
      */
     public function sync(User $user): Response
     {
-        if ($user->cannot('declaration:read') || $user->cannot('declaration_request:read') || $user->cannot('person:read')) {
-            return Response::denyWithStatus(404);
+        if ($user->can('declaration:read') && $user->can('declaration_request:read') && $user->can('person:read')) {
+            return Response::allow();
         }
 
-        return Response::allow();
+        return Response::denyWithStatus(404);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,6 +16,7 @@ use App\Jobs\HealthcareServiceSync;
 use App\Jobs\ImmunizationSync;
 use App\Jobs\LegalEntitySync;
 use App\Jobs\ObservationSync;
+use App\Jobs\PersonAuthMethodSync;
 use App\Rules\TranslatedDateValidator;
 use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
 use Fruitcake\LaravelDebugbar\ServiceProvider as DebugbarServiceProvider;
@@ -119,6 +120,11 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute(config('ehealth.rate_limit.declaration'))->by($job->user->id);
         });
 
+        RateLimiter::for('ehealth-declaration-request-get', function (object $job) {
+            return Limit::perMinute(config('ehealth.rate_limit.declaration_request'))->by($job->user->id);
+        });
+
+
         RateLimiter::for(
             'ehealth-episode-get',
             static fn (EpisodeSync $job) => Limit::perMinute(config('ehealth.rate_limit.episode'))->by($job->user->id)
@@ -157,6 +163,11 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for(
             'legal-entity-legators-get',
             static fn (LegalEntitySync $job) => Limit::perMinute(config('ehealth.rate_limit.legal_entity_legators'))->by($job->user->id)
+        );
+
+        RateLimiter::for(
+            'person-authentication-method-get',
+            static fn (PersonAuthMethodSync $job) => Limit::perMinute(config('ehealth.rate_limit.person_authentication_method'))->by($job->user->id)
         );
     }
 }

--- a/app/Traits/BatchLegalEntityQueries.php
+++ b/app/Traits/BatchLegalEntityQueries.php
@@ -18,6 +18,7 @@ use App\Models\Employee\Employee;
 use App\Models\DeclarationRequest;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Collection;
+use App\Jobs\PersonAuthMethodSync;
 use Illuminate\Support\Facades\Bus;
 use App\Jobs\EmployeeDetailsUpsert;
 use Illuminate\Bus\BatchRepository;
@@ -26,6 +27,7 @@ use App\Models\Employee\EmployeeRequest;
 use App\Models\Relations\ConfidantPerson;
 use App\Jobs\EmployeeRequestDetailsUpsert;
 use App\Jobs\DeclarationRequestDetailsSync;
+use App\Models\Relations\AuthenticationMethod;
 
 /**
  * Trait for querying batches by legal_entity_id
@@ -393,7 +395,8 @@ trait BatchLegalEntityQueries
      *
      * @param  LegalEntity  $legalEntity
      * @param  EHealthJob|null  $nextEntity  The job to be executed after the chain completes (or null)
-     * @return EHealthJob|null The first job in the EmployeeDetailsUpsert chain, or null if there are no employees
+     *
+     * @return EHealthJob|null The first job in the ConfidantPersonSync chain, or null if there are no confidant_persons
      */
     protected function getConfidantPersonStartJob(LegalEntity $legalEntity, ?EHealthJob $nextEntity): ?EHealthJob
     {
@@ -410,6 +413,44 @@ trait BatchLegalEntityQueries
         foreach ($models->reverse() as $index => $model) {
             $job = new ConfidantPersonSync(
                 confidantPerson: $model,
+                legalEntity: $legalEntity,
+                nextEntity: $previousJob
+            );
+
+            $previousJob = $job;
+        }
+
+        // Here $job is the first job in the chain (or null if no employees)
+        return $job ?? $previousJob;
+    }
+
+    /**
+     * TODO: leave it for now, but we can remove it later if we don't need it anymore
+     * Creates a chain of PersonAuthMethodSync jobs for all authentication methods with PARTIAL sync status.
+     *
+     * Jobs are created in reverse order, each next job receives the previous one as nextEntity.
+     * Returns the first job in the chain (or null if there are no authentication methods).
+     * So the jobs will be executed in the original order one by one.
+     *
+     * @param  LegalEntity  $legalEntity
+     * @param  EHealthJob|null  $nextEntity  The job to be executed after the chain completes (or null)
+     *
+     * @return EHealthJob|null The first job in the PersonAuthMethodSync chain, or null if there are no authentication methods
+     */
+    protected function getPersonAuthMethodStartJob(LegalEntity $legalEntity, ?EHealthJob $nextEntity): ?EHealthJob
+    {
+        $job = null;
+
+        // The incoming $nextEntity will be executed after the whole chain
+        $previousJob = $nextEntity;
+
+        $models = AuthenticationMethod::with('authenticatable')
+            ->where('authenticatable_type', 'App\Models\Person\Person')
+            ->get();
+
+        foreach ($models->reverse() as $model) {
+            $job = new PersonAuthMethodSync(
+                person: $model->authenticatable,
                 legalEntity: $legalEntity,
                 nextEntity: $previousJob
             );

--- a/config/ehealth.php
+++ b/config/ehealth.php
@@ -93,7 +93,8 @@ return [
         'party_request' => 30,
         'declaration' => 10,
         'declaration_request' => 20,
-        'legal_entity_legators' => 2
+        'legal_entity_legators' => 2,
+        'person_authentication_method' => 20,
     ],
     'employee_type' => [
         'OWNER' => [
@@ -449,7 +450,7 @@ return [
     'legal_entity_emergency_providing_conditions' => ['FIELD'],
 
     // https://e-health-ua.atlassian.net/wiki/spaces/ESOZ/pages/17570234464/DRAFT+REST+API+Create+Declaration+Request+V3+API-005-014-0001#Validate-Legal-Entity-Type
-    'declaration_request_legal_entity_types' => ['MSP', 'PRIMARY_CARE', 'MSP_PHARMACY'],
+    'declaration_request_legal_entity_types' => ['MSP', 'PRIMARY_CARE', 'MSP_PHARMACY', 'MSP_LIMITED'],
 
     // https://e-health-ua.atlassian.net/wiki/spaces/EH/pages/18504778043/NEW+Equipment+dictionaries+and+configurable+parameters+OMB-126
     'equipment_types_with_required_serial_number' => ['Z1203010502'],


### PR DESCRIPTION
This PR concerns the #190 ISSUE 

Що було зроблено:
- пофікшено помилку при валідації даних, які отримує запит `Get Person Authentication methods` - деякі THIRD PERSON не мають alias, тому тут додається значення тимчасове значення alias (поки не відбудеться синхронізація Person Details);
- пофікшено критичний баг, який перешкоджав відновленню призупиненої джоби;
- пофікшено ряд помилок при синхронізації декларацій, серед них пропуск синхронізації confidant person, якщо синхронізація відбувається по натисканню відповідної кнопки на сторінці декларацій;
- додано синхронізацію методів автентифікації для пацієнтів при синхронізації декларацій. Додано новий джоб `PersonAuthMethodSync`;
- пофікшено політики для декларацій, які перешкоджали появі пункту "Декларації" на сайдбарі для реорганізованого закладу;
- пофікшено трейт ліміти для запитів GetDeclarationRequest by ID:
- невеликий рефакторинг коду.