### PR TITLE
#393 Fix contract request list sync (ESOZ typed URL)

### DIFF
--- a/app/Classes/eHealth/Api/ContractRequest.php
+++ b/app/Classes/eHealth/Api/ContractRequest.php
@@ -356,18 +356,21 @@ class ContractRequest extends EHealthRequest
     {
         $transformedData = [];
         foreach ($response->getData() as $item) {
-            $transformedData[] = self::replaceEHealthPropNames($item);
+            $transformedData[] = self::normalizeListItem(
+                self::replaceEHealthPropNames($item)
+            );
         }
 
-        // Validate filters based on user's URL example
+        // List items may lack contract_number and nhs_signer_id (e.g. NEW / early statuses).
+        // See API-005-012-0007 — both fields are optional in the list response.
         $validator = Validator::make($transformedData, [
             '*.uuid' => 'required|uuid',
             '*.status' => 'required|string',
-            '*.contract_number' => 'required|string',
-            '*.contractor_legal_entity_id' => 'sometimes|uuid',
-            '*.contractor_owner_id' => 'sometimes|uuid',
-            '*.nhs_signer_id' => 'sometimes|uuid',
-            '*.edrpou' => 'sometimes|string',
+            '*.contract_number' => 'sometimes|nullable|string',
+            '*.contractor_legal_entity_id' => 'sometimes|nullable|uuid',
+            '*.contractor_owner_id' => 'sometimes|nullable|uuid',
+            '*.nhs_signer_id' => 'sometimes|nullable|string',
+            '*.edrpou' => 'sometimes|nullable|string',
         ]);
 
         if ($validator->fails()) {
@@ -686,5 +689,22 @@ class ContractRequest extends EHealthRequest
         }
 
         return $replaced;
+    }
+
+    /**
+     * Normalize optional list fields: eHealth may send "" instead of null for absent UUIDs.
+     *
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    protected static function normalizeListItem(array $item): array
+    {
+        foreach (['contract_number', 'contractor_legal_entity_id', 'contractor_owner_id', 'nhs_signer_id', 'edrpou'] as $field) {
+            if (array_key_exists($field, $item) && $item[$field] === '') {
+                $item[$field] = null;
+            }
+        }
+
+        return $item;
     }
 }

--- a/app/Classes/eHealth/Api/ContractRequest.php
+++ b/app/Classes/eHealth/Api/ContractRequest.php
@@ -24,20 +24,18 @@ class ContractRequest extends EHealthRequest
 
     /**
      * Gets a list of contract requests from E-Health.
+     *
+     * ESOZ API-005-012-0007: GET /api/contract_requests/{contract_type}
      */
     public function getMany(string $contractType, $query = null): PromiseInterface|EHealthResponse
     {
         $this->setValidator($this->validateMany(...));
         $this->setDefaultPageSize();
 
-        // Combining existing query parameters with passed ones
         $mergedQuery = array_merge($this->options['query'] ?? [], $query ?? []);
+        $url = self::URL . '/' . strtolower($contractType);
 
-        // Pass the type as a query parameter, not part of the URL
-        $mergedQuery['type'] = strtoupper($contractType);
-
-        // We use the base URL (self::URL), the parameters will go to the query string
-        return $this->get(self::URL, $mergedQuery);
+        return $this->get($url, $mergedQuery);
     }
 
     /**
@@ -72,7 +70,7 @@ class ContractRequest extends EHealthRequest
             'contract_number' => $data['contract_number'] ?? null,
             'status' => $data['status'],
             'status_reason' => $data['status_reason'] ?? null,
-            'type' => $data['type'] ?? 'REIMBURSEMENT', // Default if missing
+            'type' => strtoupper((string) ($data['type'] ?? $data['contract_type'] ?? 'REIMBURSEMENT')),
             'id_form' => $data['id_form'] ?? null,
 
             // Dates
@@ -378,7 +376,7 @@ class ContractRequest extends EHealthRequest
             throw ValidationException::withMessages(['ehealth_error' => $error]);
         }
 
-        return $validator->validated();
+        return $transformedData;
     }
 
     /**
@@ -641,6 +639,9 @@ class ContractRequest extends EHealthRequest
             switch ($name) {
                 case 'id':
                     $replaced['uuid'] = $value;
+                    break;
+                case 'contract_type':
+                    $replaced['type'] = is_string($value) ? strtoupper($value) : $value;
                     break;
                 case 'party':
                 case 'contractor_legal_entity':

--- a/app/Jobs/ContractRequestSync.php
+++ b/app/Jobs/ContractRequestSync.php
@@ -33,11 +33,10 @@ class ContractRequestSync extends EHealthJob
         ?EHealthJob $nextEntity = null,
         bool $isFirstLogin = false,
         ?User $user = null,
-        string $contractType = 'REIMBURSEMENT'
+        string $contractType = 'REIMBURSEMENT',
+        int $page = 1,
     ) {
-        // 1.Call the parent constructor with the correct types
-        // Signature: (LegalEntity $legalEntity, ? EHealthJob $nextEntity, $isFirstLogin drawing, int $page, $standalone drawing)
-        parent::__construct($legalEntity, $nextEntity, $isFirstLogin);
+        parent::__construct($legalEntity, $nextEntity, $isFirstLogin, $page);
 
         // 2.Initialize our specific properties
         $this->contractType = $contractType;
@@ -58,6 +57,7 @@ class ContractRequestSync extends EHealthJob
             ->withToken($token)
             ->getMany($this->contractType, [
                 'contractor_legal_entity_id' => $this->legalEntity->uuid,
+                'page' => $this->page,
             ]);
     }
 

--- a/app/Livewire/ContractRequest/ContractRequestIndex.php
+++ b/app/Livewire/ContractRequest/ContractRequestIndex.php
@@ -106,15 +106,20 @@ class ContractRequestIndex extends Component
         $encryptedToken = Crypt::encryptString($token);
 
         $types = ['capitation', 'reimbursement'];
-        $batchJobs = [];
+        $batchJob = null;
         $syncedCount = 0;
+        $syncErrors = [];
 
-        foreach ($types as $type) {
+        foreach ($types as $index => $type) {
+            if ($index === 1 && $batchJob !== null) {
+                break;
+            }
+
             try {
                 $response = EHealth::contractRequest()
                     ->withToken($token)
                     ->getMany($type, [
-                        'contractor_legal_entity_id' => $currentLegalEntity->uuid
+                        'contractor_legal_entity_id' => $currentLegalEntity->uuid,
                     ]);
 
                 $data = $response->validate();
@@ -128,22 +133,23 @@ class ContractRequestIndex extends Component
                 }
 
                 if ($response->isNotLast()) {
-                    $batchJobs[] = new ContractRequestSync(
+                    $batchJob = new ContractRequestSync(
                         legalEntity: $currentLegalEntity,
                         nextEntity: null,
                         isFirstLogin: false,
                         user: $user,
                         contractType: strtoupper($type),
+                        page: 2,
                     );
                 }
-
             } catch (\Exception $e) {
                 Log::error("ContractRequest sync ($type) error.", ['error' => $e->getMessage()]);
+                $syncErrors[] = "$type: {$e->getMessage()}";
             }
         }
 
-        if (!empty($batchJobs)) {
-            Bus::batch($batchJobs)
+        if ($batchJob !== null) {
+            Bus::batch([$batchJob])
                 ->withOption('legal_entity_id', $currentLegalEntity->id)
                 ->withOption('token', $encryptedToken)
                 ->withOption('user', $user)
@@ -182,7 +188,14 @@ class ContractRequestIndex extends Component
             }
         }
 
-        $this->dispatch('flashMessage', ['message' => $msg, 'type' => 'success']);
+        if (!empty($syncErrors)) {
+            $msg = implode('; ', $syncErrors) . ($syncedCount > 0 ? " ({$syncedCount} items saved before error)" : '');
+        }
+
+        $this->dispatch('flashMessage', [
+            'message' => $msg,
+            'type' => empty($syncErrors) ? 'success' : 'error',
+        ]);
     }
 
     /**

--- a/tests/Feature/Contract/ContractRequestApiTest.php
+++ b/tests/Feature/Contract/ContractRequestApiTest.php
@@ -13,9 +13,9 @@ use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 
 /**
- * Tests for ContractRequest API class bugs:
+ * Tests for ContractRequest API class:
  *  - create() must use POST /api/contract_requests/{contract_type}/{id}
- *  - getMany() must not throw when options['query'] is null
+ *  - getMany() must use GET /api/contract_requests/{contract_type} (API-005-012-0007)
  *  - validateDetails() must not fail for NEW status contract requests
  */
 class ContractRequestApiTest extends TestCase
@@ -109,9 +109,46 @@ class ContractRequestApiTest extends TestCase
         $api->getMany('reimbursement', ['contractor_legal_entity_id' => 'some-entity-uuid']);
 
         Http::assertSent(static function (Request $request): bool {
-            return str_contains($request->url(), 'contractor_legal_entity_id=some-entity-uuid')
-                && str_contains($request->url(), 'type=REIMBURSEMENT');
+            $path = parse_url($request->url(), PHP_URL_PATH) ?? '';
+
+            return $request->method() === 'GET'
+                && str_ends_with($path, '/api/contract_requests/reimbursement')
+                && str_contains($request->url(), 'contractor_legal_entity_id=some-entity-uuid')
+                && !str_contains($request->url(), 'type=');
         });
+    }
+
+    public function test_get_many_passes_page_query_param(): void
+    {
+        Http::fake([
+            '*' => Http::response([
+                'data' => [],
+                'paging' => ['page_number' => 2, 'total_pages' => 3],
+            ], 200),
+        ]);
+
+        $api = $this->makeApi();
+        $api->getMany('capitation', ['contractor_legal_entity_id' => 'entity-uuid', 'page' => 2]);
+
+        Http::assertSent(static function (Request $request): bool {
+            return str_ends_with(parse_url($request->url(), PHP_URL_PATH) ?? '', '/api/contract_requests/capitation')
+                && str_contains($request->url(), 'page=2');
+        });
+    }
+
+    public function test_validate_many_maps_contract_type_to_type(): void
+    {
+        $api = new ContractRequest();
+        $response = $this->makeEHealthResponseForMany($api, [[
+            'id' => 'c4f40d3a-1111-2222-3333-444455556666',
+            'contract_type' => 'CAPITATION',
+            'status' => 'NEW',
+            'contract_number' => '0001-CAP-0001',
+        ]]);
+
+        $result = $response->validate();
+
+        $this->assertSame('CAPITATION', $result[0]['type']);
     }
 
     // -----------------------------------------------------------------------
@@ -225,6 +262,37 @@ class ContractRequestApiTest extends TestCase
         $api->stub($stubs);
 
         return $api;
+    }
+
+    public function test_map_create_maps_contract_type_field(): void
+    {
+        $api = new ContractRequest();
+        $mapped = $api->mapCreate([
+            'id' => 'uuid-1',
+            'status' => 'NEW',
+            'contract_type' => 'CAPITATION',
+        ]);
+
+        $this->assertSame('CAPITATION', $mapped['type']);
+    }
+
+    /**
+     * Build an EHealthResponse wired to ContractRequest::validateMany() via reflection.
+     */
+    private function makeEHealthResponseForMany(ContractRequest $api, array $data): EHealthResponse
+    {
+        $guzzleResponse = new GuzzleResponse(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode(['data' => $data])
+        );
+
+        $reflector = new \ReflectionClass($api);
+        $method = $reflector->getMethod('validateMany');
+        $method->setAccessible(true);
+        $validator = $method->getClosure($api);
+
+        return new EHealthResponse($guzzleResponse, $validator);
     }
 
     /**

--- a/tests/Feature/Contract/ContractRequestApiTest.php
+++ b/tests/Feature/Contract/ContractRequestApiTest.php
@@ -151,6 +151,23 @@ class ContractRequestApiTest extends TestCase
         $this->assertSame('CAPITATION', $result[0]['type']);
     }
 
+    public function test_validate_many_allows_missing_contract_number_and_empty_nhs_signer(): void
+    {
+        $api = new ContractRequest();
+        $response = $this->makeEHealthResponseForMany($api, [[
+            'id' => 'c4f40d3a-1111-2222-3333-444455556666',
+            'contract_type' => 'REIMBURSEMENT',
+            'status' => 'NEW',
+            'nhs_signer_id' => '',
+        ]]);
+
+        $validated = $response->validate();
+
+        $this->assertSame('NEW', $validated[0]['status']);
+        $this->assertNull($validated[0]['contract_number'] ?? null);
+        $this->assertNull($validated[0]['nhs_signer_id']);
+    }
+
     // -----------------------------------------------------------------------
     // validateDetails() — tested directly without making an HTTP call
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Use ESOZ-typed list URL `GET /api/contract_requests/{contract_type}` instead of `?type=` query param in `ContractRequest::getMany()`.
- Pass `page` from `ContractRequestSync` / hybrid sync batch jobs so `EHealthJob` pagination works.
- Map `contract_type` → `type` in list responses; preserve full list payload after validation.
- Sequential hybrid sync: if capitation needs more pages, defer reimbursement to the job chain (no parallel batches).
- Show sync API/validation errors in the UI flash instead of silently logging only.

Closes #393

## Test plan

- [x] `php artisan test tests/Feature/Contract/ContractRequestApiTest.php` (16 tests)
- [x] Manual sync on `/dashboard/1/contract-request` against preprod ESOZ
- [ ] Verify logs show `GET /api/contract_requests/capitation?...` and `.../reimbursement?...`