### PR TITLE
#402 Normalize empty division_id in employee create

### DIFF
--- a/app/Livewire/Employee/Forms/EmployeeForm.php
+++ b/app/Livewire/Employee/Forms/EmployeeForm.php
@@ -566,6 +566,9 @@ class EmployeeForm extends Form
         // --- 1. Root fields ---
         $formData['startDate'] = $toApiDate($formData['startDate'] ?? null);
         $formData['endDate'] = $toApiDate($formData['endDate'] ?? null);
+        if (($formData['divisionId'] ?? null) === '') {
+            $formData['divisionId'] = null;
+        }
 
         // --- 2. Identity (Party) ---
         if (isset($formData['party']['birthDate'])) {

--- a/tests/Unit/Livewire/Employee/EmployeeFormPreparedDataTest.php
+++ b/tests/Unit/Livewire/Employee/EmployeeFormPreparedDataTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Livewire\Employee;
+
+use App\Livewire\Employee\Forms\EmployeeForm;
+use Livewire\Component;
+use Tests\TestCase;
+
+class EmployeeFormPreparedDataTest extends TestCase
+{
+    private function makeForm(): EmployeeForm
+    {
+        return new EmployeeForm(new class extends Component
+        {
+            public function render()
+            {
+                return '';
+            }
+        }, 'form');
+    }
+
+    public function test_get_prepared_data_normalizes_empty_division_id_to_null(): void
+    {
+        $form = $this->makeForm();
+        $form->divisionId = '';
+
+        $preparedData = $form->getPreparedData();
+
+        $this->assertArrayHasKey('division_id', $preparedData);
+        $this->assertNull($preparedData['division_id']);
+    }
+
+    public function test_get_prepared_data_keeps_selected_division_id(): void
+    {
+        $form = $this->makeForm();
+        $form->divisionId = '15';
+
+        $preparedData = $form->getPreparedData();
+
+        $this->assertSame('15', $preparedData['division_id']);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize empty `divisionId` (`''`) to `null` in `EmployeeForm::getPreparedData()`
- prevent SQL bigint cast error when user switches division back to "Обрати підрозділ"
- add focused unit tests for prepared data division normalization

## Test plan
- [x] `vendor/bin/sail artisan test --compact tests/Unit/Livewire/Employee/EmployeeFormPreparedDataTest.php`
- [ ] Manual: select division, then switch back to "Обрати підрозділ", save draft successfully

Closes #402