### PR TITLE
#422 fix diagnostic report actions and pagination

### DIFF
--- a/app/Livewire/Person/Records/PatientDiagnosticReports.php
+++ b/app/Livewire/Person/Records/PatientDiagnosticReports.php
@@ -28,6 +28,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\View\View;
 use Livewire\WithFileUploads;
 use Livewire\WithPagination;
@@ -47,6 +48,8 @@ class PatientDiagnosticReports extends BasePatientComponent
     public bool $showSignatureModal = false;
 
     public ?int $cancellingDiagnosticReportId = null;
+
+    public bool $fromDb = true;
 
     public array $diagnosticReports = [];
 
@@ -131,6 +134,8 @@ class PatientDiagnosticReports extends BasePatientComponent
     {
         $this->validate($this->filterValidationRules());
 
+        $this->fromDb = false;
+
         $this->resetPage();
 
         $this->loadDiagnosticReports($this->buildSearchParams());
@@ -151,6 +156,8 @@ class PatientDiagnosticReports extends BasePatientComponent
         ]);
 
         $this->resetPage();
+
+        $this->fromDb = false;
 
         $this->loadDiagnosticReports($this->buildSearchParams());
     }
@@ -200,9 +207,46 @@ class PatientDiagnosticReports extends BasePatientComponent
         $this->loadEncounters();
     }
 
-    public function openDiagnosticReportCancellation(int $diagnosticReportId): void
+    public function openDiagnosticReportView(string $diagnosticReportUuid): void
     {
-        $diagnosticReport = Repository::diagnosticReport()->findById($diagnosticReportId);
+        $diagnosticReport = $this->findDiagnosticReportForAction($diagnosticReportUuid);
+
+        if (!$diagnosticReport) {
+            return;
+        }
+
+        if ($this->prepersonId !== null) {
+            $this->redirectRoute(
+                'prepersons.diagnostic-report.view',
+                [
+                    legalEntity(),
+                    'preperson' => $this->prepersonId,
+                    'diagnosticReportId' => $diagnosticReport->id,
+                ],
+                navigate: true
+            );
+
+            return;
+        }
+
+        $this->redirectRoute(
+            'diagnostic-report.view',
+            [
+                legalEntity(),
+                'person' => $this->personId,
+                'diagnosticReportId' => $diagnosticReport->id,
+            ],
+            navigate: true
+        );
+    }
+
+    public function openDiagnosticReportCancellation(string $diagnosticReportUuid): void
+    {
+        $diagnosticReport = $this->findDiagnosticReportForAction($diagnosticReportUuid);
+
+        if (!$diagnosticReport) {
+            return;
+        }
 
         if ($message = $this->getCancellationForbiddenMessage($diagnosticReport)) {
             Session::flash('error', $message);
@@ -363,6 +407,23 @@ class PatientDiagnosticReports extends BasePatientComponent
         Session::flash('success', __('patients.messages.diagnostic_report_cancel_request_sent'));
     }
 
+    private function findDiagnosticReportForAction(string $diagnosticReportUuid): ?DiagnosticReport
+    {
+        if (blank($diagnosticReportUuid)) {
+            Session::flash('error', __('patients.messages.diagnostic_report_not_found'));
+
+            return null;
+        }
+
+        try {
+            return Repository::diagnosticReport()->findByUuid($diagnosticReportUuid);
+        } catch (ModelNotFoundException) {
+            Session::flash('error', __('patients.messages.diagnostic_report_not_found_in_db'));
+
+            return null;
+        }
+    }
+
     private function getCancellationForbiddenMessage(DiagnosticReport $diagnosticReport): ?string
     {
         if ($diagnosticReport->status === DiagnosticReportStatus::ENTERED_IN_ERROR) {
@@ -470,6 +531,12 @@ class PatientDiagnosticReports extends BasePatientComponent
 
     public function updatedPage(): void
     {
+        if ($this->fromDb) {
+            $this->loadDiagnosticReportsFromDb();
+
+            return;
+        }
+
         $this->loadDiagnosticReports($this->buildSearchParams());
     }
 
@@ -503,22 +570,26 @@ class PatientDiagnosticReports extends BasePatientComponent
 
     private function loadDiagnosticReportsFromDb(): void
     {
-        $diagnosticReports = DiagnosticReport::withAllRelations()
-            ->forPatient($this->patient())
-            ->get();
+        $paginator = Repository::diagnosticReport()->getPaginatedByPatient(
+            $this->patient(),
+            $this->getPage(),
+            $this->pageSize
+        );
 
-        $this->totalEntries = $diagnosticReports->count();
+        $this->totalEntries = $paginator->total();
+        $this->pageSize = $paginator->perPage();
 
-        $this->diagnosticReports = $diagnosticReports
-            ->map(function (DiagnosticReport $diagnosticReport) {
-                $data = Arr::toCamelCase($diagnosticReport->toArray());
-                $data['id'] = $diagnosticReport->id;
+        $this->diagnosticReports = $this->formatDatesForDisplay(
+            $paginator
+                ->getCollection()
+                ->map(function (DiagnosticReport $diagnosticReport): array {
+                    $data = Arr::toCamelCase($diagnosticReport->toArray());
+                    $data['id'] = $diagnosticReport->id;
 
-                return $data;
-            })
-            ->toArray();
-
-        $this->diagnosticReports = $this->formatDatesForDisplay($this->diagnosticReports);
+                    return $data;
+                })
+                ->toArray()
+        );
     }
 
     private function loadEpisodes(): void

--- a/app/Repositories/MedicalEvents/DiagnosticReportRepository.php
+++ b/app/Repositories/MedicalEvents/DiagnosticReportRepository.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Throwable;
 
 /**
@@ -235,7 +236,7 @@ class DiagnosticReportRepository extends BaseRepository
             ]);
 
             $ownerColumn = $diagnosticReport->prepersonId !== null ? 'preperson_id' : 'person_id';
-
+            
             Observation::query()
                 ->where($ownerColumn, $diagnosticReport->getAttribute($ownerColumn))
                 ->whereHas('diagnosticReport', fn (Builder $query) => $query->where('value', $diagnosticReport->uuid))
@@ -294,6 +295,28 @@ class DiagnosticReportRepository extends BaseRepository
     }
 
     /**
+     * Get paginated diagnostic reports related to the patient.
+     *
+     * @param  Person|Preperson  $patient
+     * @param  int  $page
+     * @param  int  $pageSize
+     * @return LengthAwarePaginator
+     */
+    public function getPaginatedByPatient(
+        Person|Preperson $patient,
+        int $page,
+        int $pageSize
+    ): LengthAwarePaginator {
+        [$ownerColumn, $ownerId] = $this->resolveOwner($patient);
+
+        return $this->model
+            ->withAllRelations()
+            ->where($ownerColumn, $ownerId)
+            ->latest()
+            ->paginate($pageSize, ['*'], 'page', $page);
+    }
+
+    /**
      * Get diagnostic report by id.
      *
      * @param  int  $diagnosticReportId
@@ -304,6 +327,20 @@ class DiagnosticReportRepository extends BaseRepository
         return $this->model
             ->withAllRelations()
             ->findOrFail($diagnosticReportId);
+    }
+
+    /**
+     * Get diagnostic report by eHealth UUID.
+     *
+     * @param  string  $uuid
+     * @return DiagnosticReport
+     */
+    public function findByUuid(string $uuid): DiagnosticReport
+    {
+        return $this->model
+            ->withAllRelations()
+            ->where('uuid', $uuid)
+            ->firstOrFail();
     }
 
     /**

--- a/app/Services/MedicalEvents/Mappers/DiagnosticReportMapper.php
+++ b/app/Services/MedicalEvents/Mappers/DiagnosticReportMapper.php
@@ -206,6 +206,29 @@ class DiagnosticReportMapper implements FhirMapperContract
             ->map(function (array $observation) use ($explanatoryLetter): array {
                 $observation = Arr::toSnakeCase($observation);
 
+                unset(
+                    $observation['inserted_at'],
+                    $observation['updated_at'],
+                    $observation['created_at'],
+                    $observation['inserted_by'],
+                    $observation['updated_by']
+                );
+
+                if ($observation['interpretation'] === null) {
+                    unset($observation['interpretation']);
+                }
+
+                $observation['components'] = collect($observation['components'] ?? [])
+                    ->map(static function (array $component): array {
+                        if (($component['interpretation'] ?? null) === null) {
+                            unset($component['interpretation']);
+                        }
+
+                        return $component;
+                    })
+                    ->values()
+                    ->toArray();
+
                 $observation['status'] = ObservationStatus::ENTERED_IN_ERROR->value;
                 $observation['explanatory_letter'] = $explanatoryLetter;
 

--- a/resources/lang/uk/patients.php
+++ b/resources/lang/uk/patients.php
@@ -627,6 +627,7 @@ return [
         'diagnostic_report_cancel_package_save_error' => 'Помилка збереження оновленого пакета діагностичного звіту після позначення внесеним помилково.',
         'diagnostic_report_end_time_cannot_be_in_future' => 'Час завершення прийому не може бути в майбутньому.',
         'diagnostic_report_not_found' => 'Діагностичний звіт не знайдено.',
+        'diagnostic_report_not_found_in_db' => 'Діагностичний звіт не знайдено в локальній базі даних. Спочатку синхронізуйте дані з ЕСОЗ.',
         'care_plans_synced_successfully' => 'Плани лікування успішно синхронізовані',
         'care_plans_first_page_synced_successfully' => 'Перша сторінка планів лікування синхронізована, решта обробляється у фоні',
         'care_plan_sync_already_running' => 'Синхронізація планів лікування вже запущена. Будь ласка, зачекайте її завершення.',

--- a/resources/views/livewire/person/records/diagnostic-reports.blade.php
+++ b/resources/views/livewire/person/records/diagnostic-reports.blade.php
@@ -746,30 +746,27 @@
                                          :id="$id('dropdown-button')"
                                          class="absolute right-0 mt-2 w-56 rounded-md bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 shadow-lg z-50 py-1"
                                     >
-                                        @if(!empty(data_get($diagnosticReport, 'id')))
-                                            <a  href="{{ $prepersonId
-                                                ? route('prepersons.diagnostic-report.view', [legalEntity(), 'preperson' => $prepersonId, 'diagnosticReportId' => data_get($diagnosticReport, 'id')])
-                                                : route('diagnostic-report.view', [legalEntity(), 'person' => $personId, 'diagnosticReportId' => data_get($diagnosticReport, 'id')]) }}"
-                                                wire:navigate
+                                        <button type="button"
+                                                @click="close($refs.button)"
+                                                wire:click="openDiagnosticReportView('{{ data_get($diagnosticReport, 'uuid') }}')"
+                                                wire:loading.attr="disabled"
+                                                wire:target="openDiagnosticReportView"
                                                 class="flex items-center gap-2 w-full px-4 py-2.5 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
-                                            >
-                                                @icon('eye', 'w-5 h-5 text-gray-500')
-                                                {{ __('patients.view_details') }}
-                                            </a>
-                                        @endif
+                                        >
+                                            @icon('eye', 'w-5 h-5 text-gray-500')
+                                            {{ __('patients.view_details') }}
+                                        </button>
 
-                                        @if(!empty(data_get($diagnosticReport, 'id')))
-                                            <button type="button"
-                                                    @click="close($refs.button)"
-                                                    wire:click="openDiagnosticReportCancellation({{ data_get($diagnosticReport, 'id') }})"
-                                                    wire:loading.attr="disabled"
-                                                    wire:target="openDiagnosticReportCancellation({{ data_get($diagnosticReport, 'id') }})"
-                                                    class="flex items-center gap-2 w-full px-4 py-2.5 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
-                                            >
-                                                @icon('alert-circle', 'w-5 h-5 text-gray-500')
-                                                {{ __('patients.status.entered_in_error') }}
-                                            </button>
-                                        @endif
+                                        <button type="button"
+                                                @click="close($refs.button)"
+                                                wire:click="openDiagnosticReportCancellation('{{ data_get($diagnosticReport, 'uuid') }}')"
+                                                wire:loading.attr="disabled"
+                                                wire:target="openDiagnosticReportCancellation"
+                                                class="flex items-center gap-2 w-full px-4 py-2.5 text-left text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
+                                        >
+                                            @icon('alert-circle', 'w-5 h-5 text-gray-500')
+                                            {{ __('patients.status.entered_in_error') }}
+                                        </button>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Closes #422 

- Added diagnostic report action menu support for records loaded from the eHealth API.
- Added local diagnostic report lookup by UUID before opening or cancelling a report.
- Added database pagination for diagnostic reports on initial page load.